### PR TITLE
feat(server): use fastmcp context for injection

### DIFF
--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -2,60 +2,66 @@
 
 from typing import Annotated
 
-from schwab_mcp.tools._protocols import AccountClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_account_client
 
 
 @register
 async def get_account_numbers(
-    client: AccountClient,
+    ctx: Context,
 ) -> str:
     """
     Returns mapping of account IDs to account hashes. Hashes required for account-specific calls. Use first.
     """
+    client = get_account_client(ctx)
     return await call(client.get_account_numbers)
 
 
 @register
 async def get_accounts(
-    client: AccountClient,
+    ctx: Context,
 ) -> str:
     """
     Returns balances/info for all linked accounts (funds, cash, margin). Does not return hashes; use get_account_numbers first.
     """
+    client = get_account_client(ctx)
     return await call(client.get_accounts)
 
 
 @register
 async def get_accounts_with_positions(
-    client: AccountClient,
+    ctx: Context,
 ) -> str:
     """
     Returns balances, info, and positions (holdings, cost, gain/loss) for all linked accounts. Does not return hashes; use get_account_numbers first.
     """
+    client = get_account_client(ctx)
     return await call(client.get_accounts, fields=[client.Account.Fields.POSITIONS])
 
 
 @register
 async def get_account(
-    client: AccountClient,
+    ctx: Context,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
 ) -> str:
     """
     Returns balance/info for a specific account via account_hash (from get_account_numbers). Includes funds, cash, margin info.
     """
+    client = get_account_client(ctx)
     return await call(client.get_account, account_hash)
 
 
 @register
 async def get_account_with_positions(
-    client: AccountClient,
+    ctx: Context,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
 ) -> str:
     """
     Returns balance, info, and positions for a specific account via account_hash. Includes holdings, quantity, cost basis, unrealized gain/loss.
     """
+    client = get_account_client(ctx)
     return await call(
         client.get_account, account_hash, fields=[client.Account.Fields.POSITIONS]
     )
@@ -63,9 +69,10 @@ async def get_account_with_positions(
 
 @register
 async def get_user_preferences(
-    client: AccountClient,
+    ctx: Context,
 ) -> str:
     """
     Returns user preferences (nicknames, display settings, notifications) for all linked accounts.
     """
+    client = get_account_client(ctx)
     return await call(client.get_user_preferences)

--- a/src/schwab_mcp/tools/history.py
+++ b/src/schwab_mcp/tools/history.py
@@ -3,9 +3,10 @@
 from typing import Annotated
 
 import datetime
-from schwab_mcp.tools._protocols import PriceHistoryClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_price_history_client
 
 
 def _parse_iso_datetime(value: str | None) -> datetime.datetime | None:
@@ -14,7 +15,7 @@ def _parse_iso_datetime(value: str | None) -> datetime.datetime | None:
 
 @register
 async def get_advanced_price_history(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     period_type: Annotated[str | None, "Period type: DAY, MONTH, YEAR, YEAR_TO_DATE"] = None,
     period: Annotated[
@@ -56,6 +57,8 @@ async def get_advanced_price_history(
       YEAR_TO_DATE: DAILY, WEEKLY (default)
     Dates must be in ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -92,7 +95,7 @@ async def get_advanced_price_history(
 
 @register
 async def get_price_history_every_minute(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T09:30:00')"
@@ -106,6 +109,8 @@ async def get_price_history_every_minute(
     """
     Get OHLCV price history per minute. For detailed intraday analysis. Max 48 days history. Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -121,7 +126,7 @@ async def get_price_history_every_minute(
 
 @register
 async def get_price_history_every_five_minutes(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T09:30:00')"
@@ -135,6 +140,8 @@ async def get_price_history_every_five_minutes(
     """
     Get OHLCV price history per 5 minutes. Balance between detail and noise. Approx. 9 months history. Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -150,7 +157,7 @@ async def get_price_history_every_five_minutes(
 
 @register
 async def get_price_history_every_ten_minutes(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T09:30:00')"
@@ -164,6 +171,8 @@ async def get_price_history_every_ten_minutes(
     """
     Get OHLCV price history per 10 minutes. Good for intraday trends/levels. Approx. 9 months history. Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -179,7 +188,7 @@ async def get_price_history_every_ten_minutes(
 
 @register
 async def get_price_history_every_fifteen_minutes(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T09:30:00')"
@@ -193,6 +202,8 @@ async def get_price_history_every_fifteen_minutes(
     """
     Get OHLCV price history per 15 minutes. Shows significant intraday moves, filters noise. Approx. 9 months history. Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -208,7 +219,7 @@ async def get_price_history_every_fifteen_minutes(
 
 @register
 async def get_price_history_every_thirty_minutes(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T09:30:00')"
@@ -222,6 +233,8 @@ async def get_price_history_every_thirty_minutes(
     """
     Get OHLCV price history per 30 minutes. For broader intraday trends, filters noise. Approx. 9 months history. Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -237,7 +250,7 @@ async def get_price_history_every_thirty_minutes(
 
 @register
 async def get_price_history_every_day(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security to fetch price history for"],
     start_datetime: Annotated[
         str | None,
@@ -257,6 +270,8 @@ async def get_price_history_every_day(
     """
     Get daily OHLCV price history. For medium/long-term analysis. Extensive history (back to 1985 possible). Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 
@@ -272,7 +287,7 @@ async def get_price_history_every_day(
 
 @register
 async def get_price_history_every_week(
-    client: PriceHistoryClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the security"],
     start_datetime: Annotated[
         str | None, "Start date for history (ISO format, e.g., '2023-01-01T00:00:00')"
@@ -286,6 +301,8 @@ async def get_price_history_every_week(
     """
     Get weekly OHLCV price history. For long-term analysis, major cycles. Extensive history (back to 1985 possible). Dates ISO format.
     """
+    client = get_price_history_client(ctx)
+
     start_dt = _parse_iso_datetime(start_datetime)
     end_dt = _parse_iso_datetime(end_datetime)
 

--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -3,9 +3,10 @@
 from typing import Annotated
 
 import datetime
-from schwab_mcp.tools._protocols import OptionsClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_options_client
 
 
 def _parse_date(value: str | datetime.date | None) -> datetime.date | None:
@@ -20,7 +21,7 @@ def _parse_date(value: str | datetime.date | None) -> datetime.date | None:
 
 @register
 async def get_option_chain(
-    client: OptionsClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the underlying security (e.g., 'AAPL', 'SPY')"],
     contract_type: Annotated[
         str | None, "Type of option contracts: CALL, PUT, or ALL (default)"
@@ -46,6 +47,8 @@ async def get_option_chain(
     Params: symbol, contract_type (CALL/PUT/ALL), strike_count (default 25), include_quotes (bool), from_date (YYYY-MM-DD), to_date (YYYY-MM-DD).
     Limit data returned using strike_count and date parameters.
     """
+    client = get_options_client(ctx)
+
     from_date_obj = _parse_date(from_date)
     to_date_obj = _parse_date(to_date)
 
@@ -65,7 +68,7 @@ async def get_option_chain(
 
 @register
 async def get_advanced_option_chain(
-    client: OptionsClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the underlying security"],
     contract_type: Annotated[str | None, "Type of contracts: CALL, PUT, or ALL (default)"] = None,
     strike_count: Annotated[
@@ -115,6 +118,8 @@ async def get_advanced_option_chain(
     Params: symbol, contract_type, strike_count, include_quotes, strategy (SINGLE/ANALYTICAL/etc.), interval, strike, strike_range (ITM/NTM/etc.), from/to_date, volatility/underlying_price/interest_rate/days_to_expiration (for ANALYTICAL), exp_month, option_type (STANDARD/NON_STANDARD/ALL).
     Limit data returned using strike_count and date parameters.
     """
+    client = get_options_client(ctx)
+
     from_date_obj = _parse_date(from_date)
     to_date_obj = _parse_date(to_date)
 
@@ -153,10 +158,11 @@ async def get_advanced_option_chain(
 
 @register
 async def get_option_expiration_chain(
-    client: OptionsClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol of the underlying security"],
 ) -> str:
     """
     Returns available option expiration dates for a symbol, without contract details. Lightweight call to find available cycles. Param: symbol.
     """
+    client = get_options_client(ctx)
     return await call(client.get_option_expiration_chain, symbol)

--- a/src/schwab_mcp/tools/quotes.py
+++ b/src/schwab_mcp/tools/quotes.py
@@ -2,14 +2,15 @@
 
 from typing import Annotated
 
-from schwab_mcp.tools._protocols import QuotesClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_quotes_client
 
 
 @register
 async def get_quotes(
-    client: QuotesClient,
+    ctx: Context,
     symbols: Annotated[
         list[str] | str, "List of symbols or comma-separated string (e.g., ['AAPL', 'MSFT'] or 'GOOG,AMZN')"
     ],
@@ -25,6 +26,8 @@ async def get_quotes(
     Returns current market quotes for specified symbols (stocks, ETFs, indices, options).
     Params: symbols (list or comma-separated string), fields (list/str: QUOTE/FUNDAMENTAL/etc.), indicative (bool).
     """
+    client = get_quotes_client(ctx)
+
     if isinstance(symbols, str):
         symbols = [s.strip() for s in symbols.split(",")]
 

--- a/src/schwab_mcp/tools/tools.py
+++ b/src/schwab_mcp/tools/tools.py
@@ -3,9 +3,10 @@
 from typing import Annotated
 
 import datetime
-from schwab_mcp.tools._protocols import ToolsClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_tools_client
 
 
 @register
@@ -18,7 +19,7 @@ async def get_datetime() -> str:
 
 @register
 async def get_market_hours(
-    client: ToolsClient,
+    ctx: Context,
     markets: Annotated[
         list[str] | str,
         "Markets (list/str): EQUITY, OPTION, BOND, FUTURE, FOREX",
@@ -31,6 +32,8 @@ async def get_market_hours(
     """
     Get market hours for specified markets (EQUITY, OPTION, etc.) on a given date (YYYY-MM-DD, default today).
     """
+    client = get_tools_client(ctx)
+
     if isinstance(markets, str):
         markets = [m.strip() for m in markets.split(",")]
 
@@ -45,7 +48,7 @@ async def get_market_hours(
 
 @register
 async def get_movers(
-    client: ToolsClient,
+    ctx: Context,
     index: Annotated[
         str,
         "Index/market: DJI, COMPX, SPX, NYSE, NASDAQ, OTCBB, INDEX_ALL, EQUITY_ALL, OPTION_ALL, OPTION_PUT, OPTION_CALL",
@@ -62,6 +65,8 @@ async def get_movers(
     Get top 10 movers for an index/market (e.g., DJI, SPX, NASDAQ).
     Params: index, sort (VOLUME/TRADES/PERCENT_CHANGE_UP/DOWN), frequency (min % change: ZERO/ONE/etc.).
     """
+    client = get_tools_client(ctx)
+
     return await call(
         client.get_movers,
         client.Movers.Index[index.upper()],
@@ -72,7 +77,7 @@ async def get_movers(
 
 @register
 async def get_instruments(
-    client: ToolsClient,
+    ctx: Context,
     symbol: Annotated[str, "Symbol or search term"],
     projection: Annotated[
         str,
@@ -102,6 +107,8 @@ async def get_instruments(
     }
     proj_upper = projection.upper()
     proj_key = projection.lower()
+
+    client = get_tools_client(ctx)
 
     if proj_key in projection_map:
         proj_enum_name = projection_map[proj_key]

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -3,14 +3,15 @@
 from typing import Annotated
 
 import datetime
-from schwab_mcp.tools._protocols import TransactionsClient
+from mcp.server.fastmcp import Context
+
 from schwab_mcp.tools.registry import register
-from schwab_mcp.tools.utils import call
+from schwab_mcp.tools.utils import call, get_transactions_client
 
 
 @register
 async def get_transactions(
-    client: TransactionsClient,
+    ctx: Context,
     account_hash: Annotated[
         str, "Account hash for the Schwab account (from get_account_numbers)"
     ],
@@ -32,6 +33,8 @@ async def get_transactions(
     Params: account_hash, start_date (YYYY-MM-DD), end_date (YYYY-MM-DD), transaction_type (list/str: TRADE/DIVIDEND_OR_INTEREST/etc.), symbol.
     Use tomorrow's date as end_date for today's transactions. See full type list in original docstring if needed.
     """
+    client = get_transactions_client(ctx)
+
     start_date_obj = None
     end_date_obj = None
 
@@ -62,7 +65,7 @@ async def get_transactions(
 
 @register
 async def get_transaction(
-    client: TransactionsClient,
+    ctx: Context,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
     transaction_id: Annotated[str, "Transaction ID (from get_transactions)"],
 ) -> str:
@@ -70,4 +73,5 @@ async def get_transaction(
     Get detailed info for a specific transaction by ID.
     Params: account_hash, transaction_id (from get_transactions).
     """
+    client = get_transactions_client(ctx)
     return await call(client.get_transaction, account_hash, transaction_id)

--- a/src/schwab_mcp/tools/utils.py
+++ b/src/schwab_mcp/tools/utils.py
@@ -1,12 +1,26 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, TypeVar, cast
 
 import mcp.types as types
 from mcp.shared.exceptions import McpError
+from mcp.server.fastmcp import Context
+from schwab.client import AsyncClient
+
+from schwab_mcp.tools._protocols import (
+    AccountClient,
+    OptionsClient,
+    OrdersClient,
+    PriceHistoryClient,
+    QuotesClient,
+    ToolsClient,
+    TransactionsClient,
+)
 
 _WRITE_ENABLED: bool = False
+_CLIENT_ATTR = "_schwab_client"
+ClientT = TypeVar("ClientT")
 
 
 async def call(func: Callable[..., Awaitable[Any]], *args: Any, **kwargs: Any) -> Any:
@@ -34,4 +48,60 @@ def ensure_write_access() -> None:
     raise McpError(types.ErrorData(code=403, message="Write tools are disabled.", data=data))
 
 
-__all__ = ["call", "set_write_enabled", "ensure_write_access"]
+def _missing_client_error() -> McpError:
+    data = {
+        "client": "unavailable",
+        "hint": "Schwab client not attached to FastMCP server.",
+    }
+    return McpError(types.ErrorData(code=500, message="Schwab client is not configured.", data=data))
+
+
+def get_client(ctx: Context) -> AsyncClient:
+    """Fetch the Schwab AsyncClient stored on the FastMCP server."""
+    client = getattr(ctx.fastmcp, _CLIENT_ATTR, None)
+    if client is None:
+        raise _missing_client_error()
+    return cast(AsyncClient, client)
+
+
+def get_tools_client(ctx: Context) -> ToolsClient:
+    return cast(ToolsClient, get_client(ctx))
+
+
+def get_account_client(ctx: Context) -> AccountClient:
+    return cast(AccountClient, get_client(ctx))
+
+
+def get_price_history_client(ctx: Context) -> PriceHistoryClient:
+    return cast(PriceHistoryClient, get_client(ctx))
+
+
+def get_options_client(ctx: Context) -> OptionsClient:
+    return cast(OptionsClient, get_client(ctx))
+
+
+def get_orders_client(ctx: Context) -> OrdersClient:
+    return cast(OrdersClient, get_client(ctx))
+
+
+def get_quotes_client(ctx: Context) -> QuotesClient:
+    return cast(QuotesClient, get_client(ctx))
+
+
+def get_transactions_client(ctx: Context) -> TransactionsClient:
+    return cast(TransactionsClient, get_client(ctx))
+
+
+__all__ = [
+    "call",
+    "set_write_enabled",
+    "ensure_write_access",
+    "get_client",
+    "get_tools_client",
+    "get_account_client",
+    "get_price_history_client",
+    "get_options_client",
+    "get_orders_client",
+    "get_quotes_client",
+    "get_transactions_client",
+]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -25,6 +25,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def make_ctx(client: Any) -> Any:
+    return SimpleNamespace(fastmcp=SimpleNamespace(_schwab_client=client))
+
+
 def test_get_advanced_price_history_normalizes_inputs(monkeypatch):
     captured: dict[str, Any] = {}
 
@@ -37,9 +41,10 @@ def test_get_advanced_price_history_normalizes_inputs(monkeypatch):
     monkeypatch.setattr(history, "call", fake_call)
 
     client = DummyHistoryClient()
+    ctx = make_ctx(client)
     result = run(
         history.get_advanced_price_history(
-            client,
+            ctx,
             "SPY",
             period_type="day",
             period="ten_days",
@@ -83,9 +88,10 @@ def test_get_price_history_every_minute_passes_flags(monkeypatch):
     monkeypatch.setattr(history, "call", fake_call)
 
     client = DummyHistoryClient()
+    ctx = make_ctx(client)
     result = run(
         history.get_price_history_every_minute(
-            client,
+            ctx,
             "MSFT",
             start_datetime="2024-02-02T09:30:00",
             end_datetime="2024-02-02T09:35:00",

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 from enum import Enum
+from types import SimpleNamespace
 from typing import Any
 
 from schwab_mcp.tools import options
@@ -28,6 +29,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def make_ctx(client: Any) -> Any:
+    return SimpleNamespace(fastmcp=SimpleNamespace(_schwab_client=client))
+
+
 def test_get_advanced_option_chain_parses_and_maps_parameters(monkeypatch):
     captured: dict[str, Any] = {}
 
@@ -40,9 +45,10 @@ def test_get_advanced_option_chain_parses_and_maps_parameters(monkeypatch):
     monkeypatch.setattr(options, "call", fake_call)
 
     client = DummyOptionsClient()
+    ctx = make_ctx(client)
     result = run(
         options.get_advanced_option_chain(
-            client,
+            ctx,
             "SPY",
             contract_type="put",
             strike_count=10,

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 from enum import Enum
+from types import SimpleNamespace
 from typing import Any
 
 from schwab_mcp.tools import orders
@@ -21,6 +22,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def make_ctx(client: Any) -> Any:
+    return SimpleNamespace(fastmcp=SimpleNamespace(_schwab_client=client))
+
+
 def test_get_orders_maps_single_status_and_dates(monkeypatch):
     captured: dict[str, Any] = {}
 
@@ -33,9 +38,10 @@ def test_get_orders_maps_single_status_and_dates(monkeypatch):
     monkeypatch.setattr(orders, "call", fake_call)
 
     client = DummyOrdersClient()
+    ctx = make_ctx(client)
     result = run(
         orders.get_orders(
-            client,
+            ctx,
             "abc123",
             max_results=25,
             from_date="2024-04-01",
@@ -71,9 +77,10 @@ def test_get_orders_maps_status_list(monkeypatch):
     monkeypatch.setattr(orders, "call", fake_call)
 
     client = DummyOrdersClient()
+    ctx = make_ctx(client)
     result = run(
         orders.get_orders(
-            client,
+            ctx,
             "xyz789",
             status=["filled", "canceled"],
         )

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -1,5 +1,6 @@
 import asyncio
 from enum import Enum
+from types import SimpleNamespace
 from typing import Any
 
 from schwab_mcp.tools import quotes
@@ -17,6 +18,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def make_ctx(client: Any) -> Any:
+    return SimpleNamespace(fastmcp=SimpleNamespace(_schwab_client=client))
+
+
 def test_get_quotes_parses_symbols_and_fields(monkeypatch):
     captured: dict[str, Any] = {}
 
@@ -29,9 +34,10 @@ def test_get_quotes_parses_symbols_and_fields(monkeypatch):
     monkeypatch.setattr(quotes, "call", fake_call)
 
     client = DummyQuotesClient()
+    ctx = make_ctx(client)
     result = run(
         quotes.get_quotes(
-            client,
+            ctx,
             "AAPL, msft",
             fields="quote, fundamental",
             indicative=False,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 from enum import Enum
+from types import SimpleNamespace
 from typing import Any
 
 from schwab_mcp.tools import tools
@@ -35,6 +36,10 @@ def run(coro):
     return asyncio.run(coro)
 
 
+def make_ctx(client: Any) -> Any:
+    return SimpleNamespace(fastmcp=SimpleNamespace(_schwab_client=client))
+
+
 def test_get_market_hours_handles_string_inputs(monkeypatch):
     captured: dict[str, Any] = {}
 
@@ -47,9 +52,10 @@ def test_get_market_hours_handles_string_inputs(monkeypatch):
     monkeypatch.setattr(tools, "call", fake_call)
 
     client = DummyToolsClient()
+    ctx = make_ctx(client)
     result = run(
         tools.get_market_hours(
-            client,
+            ctx,
             "equity, option",
             date="2024-03-01",
         )
@@ -84,9 +90,10 @@ def test_get_movers_maps_enums(monkeypatch):
     monkeypatch.setattr(tools, "call", fake_call)
 
     client = DummyToolsClient()
+    ctx = make_ctx(client)
     result = run(
         tools.get_movers(
-            client,
+            ctx,
             "spx",
             sort="percent_change_up",
             frequency="five",
@@ -118,9 +125,10 @@ def test_get_instruments_supports_aliases(monkeypatch):
     monkeypatch.setattr(tools, "call", fake_call)
 
     client = DummyToolsClient()
+    ctx = make_ctx(client)
     result = run(
         tools.get_instruments(
-            client,
+            ctx,
             "AAPL",
             projection="symbol-search",
         )


### PR DESCRIPTION
The FastMCP server allows for context injection. Store the schwab client in this context instead of custom injection.