### PR TITLE
feat(mcp): default to toon encoding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "httpx>=0.27.2",
     "mcp>=1.17.0",
     "platformdirs>=4.5.0",
+    "python-toon>=0.1.2",
     "pyyaml>=6.0.3",
     "schwab-py>=1.5.1",
 ]

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -146,6 +146,13 @@ def auth(
     envvar="SCHWAB_MCP_DISCORD_TIMEOUT",
     help="Seconds to wait for Discord approval before timing out.",
 )
+@click.option(
+    "--json",
+    "json_output",
+    default=False,
+    is_flag=True,
+    help="Return JSON payloads from tools instead of Toon-encoded strings.",
+)
 def server(
     token_path: str,
     client_id: str,
@@ -157,6 +164,7 @@ def server(
     discord_approver: tuple[str, ...],
     discord_timeout: int,
     no_technical_tools: bool,
+    json_output: bool,
 ) -> int:
     """Run the Schwab MCP server."""
     # No logging to stderr when in MCP mode (we'll use proper MCP responses)
@@ -266,6 +274,7 @@ def server(
             approval_manager=approval_manager,
             allow_write=allow_write,
             enable_technical_tools=not no_technical_tools,
+            use_json=json_output,
         )
         anyio.run(server.run, backend="asyncio")
         return 0

--- a/src/schwab_mcp/tools/__init__.py
+++ b/src/schwab_mcp/tools/__init__.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import logging
 
+from collections.abc import Callable
+from typing import Any
+
 from mcp.server.fastmcp import FastMCP
 from schwab.client import AsyncClient
 
@@ -33,6 +36,7 @@ def register_tools(
     *,
     allow_write: bool,
     enable_technical: bool = True,
+    result_transform: Callable[[Any], Any] | None = None,
 ) -> None:
     """Register all Schwab tools with the provided FastMCP server."""
     _ = client
@@ -45,7 +49,11 @@ def register_tools(
         register_module = getattr(module, "register", None)
         if register_module is None:
             raise AttributeError(f"Tool module {module.__name__} missing register()")
-        register_module(server, allow_write=allow_write)
+        register_module(
+            server,
+            allow_write=allow_write,
+            result_transform=result_transform,
+        )
 
 
 __all__ = ["register_tools"]

--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -1,6 +1,7 @@
 #
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -82,7 +83,12 @@ _READ_ONLY_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/src/schwab_mcp/tools/history.py
+++ b/src/schwab_mcp/tools/history.py
@@ -1,6 +1,7 @@
 #
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 import datetime
 from mcp.server.fastmcp import FastMCP
@@ -322,7 +323,12 @@ _READ_ONLY_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -1,5 +1,6 @@
 #
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 import datetime
 from mcp.server.fastmcp import FastMCP
@@ -202,7 +203,12 @@ _READ_ONLY_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -1,5 +1,6 @@
 #
 
+from collections.abc import Callable
 from typing import Annotated, Any, cast
 
 import copy
@@ -738,12 +739,17 @@ _WRITE_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)
 
     if not allow_write:
         return
 
     for func in _WRITE_TOOLS:
-        register_tool(server, func, write=True)
+        register_tool(server, func, write=True, result_transform=result_transform)

--- a/src/schwab_mcp/tools/quotes.py
+++ b/src/schwab_mcp/tools/quotes.py
@@ -1,6 +1,6 @@
 #
-
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 
@@ -49,7 +49,12 @@ async def get_quotes(
 _READ_ONLY_TOOLS = (get_quotes,)
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/src/schwab_mcp/tools/technical/__init__.py
+++ b/src/schwab_mcp/tools/technical/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import importlib
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 if TYPE_CHECKING:
     from mcp.server.fastmcp import FastMCP
@@ -18,7 +18,12 @@ except ModuleNotFoundError:
 pandas_ta = cast(Any, _pandas_ta)
 
 
-def register(server: "FastMCP", *, allow_write: bool) -> None:
+def register(
+    server: "FastMCP",
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     """Register optional technical analysis tools if dependencies are available."""
     _ = allow_write
 
@@ -34,7 +39,11 @@ def register(server: "FastMCP", *, allow_write: bool) -> None:
             raise AttributeError(
                 f"Technical tool module {module.__name__} is missing register()"
             )
-        register_fn(server, allow_write=allow_write)
+        register_fn(
+            server,
+            allow_write=allow_write,
+            result_transform=result_transform,
+        )
 
     logger.debug("Technical analysis tools registered from %s", ", ".join(_MODULE_PATHS))
 

--- a/src/schwab_mcp/tools/technical/momentum.py
+++ b/src/schwab_mcp/tools/technical/momentum.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
@@ -176,7 +177,12 @@ async def stoch(
     }
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
-    register_tool(server, rsi)
-    register_tool(server, stoch)
+    register_tool(server, rsi, result_transform=result_transform)
+    register_tool(server, stoch, result_transform=result_transform)

--- a/src/schwab_mcp/tools/technical/moving_average.py
+++ b/src/schwab_mcp/tools/technical/moving_average.py
@@ -157,7 +157,12 @@ async def ema(
     )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
-    register_tool(server, sma)
-    register_tool(server, ema)
+    register_tool(server, sma, result_transform=result_transform)
+    register_tool(server, ema, result_transform=result_transform)

--- a/src/schwab_mcp/tools/technical/overlays.py
+++ b/src/schwab_mcp/tools/technical/overlays.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
@@ -256,8 +257,13 @@ async def bollinger_bands(
     }
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
-    register_tool(server, vwap)
-    register_tool(server, pivot_points)
-    register_tool(server, bollinger_bands)
+    register_tool(server, vwap, result_transform=result_transform)
+    register_tool(server, pivot_points, result_transform=result_transform)
+    register_tool(server, bollinger_bands, result_transform=result_transform)

--- a/src/schwab_mcp/tools/technical/trend.py
+++ b/src/schwab_mcp/tools/technical/trend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
@@ -233,8 +234,13 @@ async def adx(
     }
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
-    register_tool(server, macd)
-    register_tool(server, atr)
-    register_tool(server, adx)
+    register_tool(server, macd, result_transform=result_transform)
+    register_tool(server, atr, result_transform=result_transform)
+    register_tool(server, adx, result_transform=result_transform)

--- a/src/schwab_mcp/tools/technical/volatility.py
+++ b/src/schwab_mcp/tools/technical/volatility.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import math
-from typing import Annotated, Any, Mapping, cast
+from typing import Annotated, Any, Callable, Mapping, cast
 
 import numpy as np
 import pandas as pd
@@ -313,10 +313,15 @@ async def expected_move(
     return response
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
-    register_tool(server, expected_move)
-    register_tool(server, historical_volatility)
+    register_tool(server, expected_move, result_transform=result_transform)
+    register_tool(server, historical_volatility, result_transform=result_transform)
 
 
 async def _fetch_option_chain(ctx: SchwabContext, symbol: str) -> Mapping[str, Any]:

--- a/src/schwab_mcp/tools/tools.py
+++ b/src/schwab_mcp/tools/tools.py
@@ -1,7 +1,8 @@
 #
 
 import datetime
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 from mcp.server.fastmcp import FastMCP
 
@@ -130,7 +131,12 @@ _READ_ONLY_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -1,6 +1,6 @@
 #
-
-from typing import Annotated
+from collections.abc import Callable
+from typing import Annotated, Any
 
 import datetime
 from mcp.server.fastmcp import FastMCP
@@ -80,7 +80,12 @@ _READ_ONLY_TOOLS = (
 )
 
 
-def register(server: FastMCP, *, allow_write: bool) -> None:
+def register(
+    server: FastMCP,
+    *,
+    allow_write: bool,
+    result_transform: Callable[[Any], Any] | None = None,
+) -> None:
     _ = allow_write
     for func in _READ_ONLY_TOOLS:
-        register_tool(server, func)
+        register_tool(server, func, result_transform=result_transform)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,6 @@
+import asyncio
 from types import SimpleNamespace
-from typing import cast
+from typing import Any, Callable, cast
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.tools import Tool
@@ -59,9 +60,14 @@ def test_register_tools_always_registers_write_tools(monkeypatch) -> None:
         """write tool"""
         return "write"
 
-    def register_module(server, *, allow_write: bool) -> None:
-        register_tool(server, read_tool)
-        register_tool(server, write_tool, write=True)
+    def register_module(
+        server,
+        *,
+        allow_write: bool,
+        result_transform: Callable[[Any], Any] | None = None,
+    ) -> None:
+        register_tool(server, read_tool, result_transform=result_transform)
+        register_tool(server, write_tool, write=True, result_transform=result_transform)
 
     dummy_module = SimpleNamespace(register=register_module)
     monkeypatch.setattr(tools_module, "_TOOL_MODULES", (dummy_module,))
@@ -91,3 +97,51 @@ def test_register_tools_always_registers_write_tools(monkeypatch) -> None:
     assert write_annotations is not None
     assert write_annotations.readOnlyHint is False
     assert write_annotations.destructiveHint is True
+
+
+def test_register_tool_applies_result_transform() -> None:
+    server = FastMCP(name="transform")
+
+    async def sample_tool() -> dict[str, str]:
+        return {"ok": "yes"}
+
+    captured: dict[str, Any] = {}
+
+    def transform(payload: Any) -> str:
+        captured["payload"] = payload
+        return "encoded"
+
+    register_tool(server, sample_tool, result_transform=transform)
+    tool = _tool_by_name(server, "sample_tool")
+
+    async def runner() -> str:
+        return await tool.fn()
+
+    result = asyncio.run(runner())
+    assert result == "encoded"
+    assert captured["payload"] == {"ok": "yes"}
+
+
+def test_result_transform_preserves_strings() -> None:
+    server = FastMCP(name="string-transform")
+
+    async def sample_tool() -> str:
+        return "already-string"
+
+    captured: dict[str, Any] = {}
+
+    def transform(payload: Any) -> str:
+        captured["payload"] = payload
+        if isinstance(payload, str):
+            return payload
+        return "encoded"
+
+    register_tool(server, sample_tool, result_transform=transform)
+    tool = _tool_by_name(server, "sample_tool")
+
+    async def runner() -> str:
+        return await tool.fn()
+
+    result = asyncio.run(runner())
+    assert result == "already-string"
+    assert captured["payload"] == "already-string"

--- a/uv.lock
+++ b/uv.lock
@@ -486,7 +486,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -1661,6 +1661,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-toon"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/3d/543134060231e40df0280b899225378cbeea1a3ec21d13ed81a9cccc7daa/python_toon-0.1.2.tar.gz", hash = "sha256:5bbdf6d498c5524e609bec9c9ed01a3995d69be96b188d245b65701fa0d54611", size = 25167, upload-time = "2025-10-30T16:20:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/3f/22d9651ac06facb97e4b76409c95ca63748613088184f0a402285fd2d44f/python_toon-0.1.2-py3-none-any.whl", hash = "sha256:bc66b1e262bf3ffbf5deee1afcf7409e4a3de4978c4aa4f73ce75c73184b9695", size = 21727, upload-time = "2025-10-30T16:20:26.486Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1954,6 +1963,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "platformdirs" },
+    { name = "python-toon" },
     { name = "pyyaml" },
     { name = "schwab-py" },
 ]
@@ -1978,6 +1988,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "mcp", specifier = ">=1.17.0" },
     { name = "platformdirs", specifier = ">=4.5.0" },
+    { name = "python-toon", specifier = ">=0.1.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "schwab-py", specifier = ">=1.5.1" },
 ]


### PR DESCRIPTION
Toon encoding reduces the payload size aproximatly 40-60% leading to less token usage. `json` format is still supported with the `--json` flag to the server.