### PR TITLE
refactor: DRY order spec builders with lookup tables

### DIFF
--- a/tests/test_build_order_spec.py
+++ b/tests/test_build_order_spec.py
@@ -79,40 +79,15 @@ class TestBuildEquityOrderSpec:
     @pytest.mark.parametrize(
         ("order_type", "price", "stop_price", "expected_error"),
         [
-            (
-                "MARKET",
-                100.0,
-                None,
-                "MARKET orders should not include price or stop_price",
-            ),
-            (
-                "MARKET",
-                None,
-                100.0,
-                "MARKET orders should not include price or stop_price",
-            ),
-            (
-                "MARKET",
-                100.0,
-                100.0,
-                "MARKET orders should not include price or stop_price",
-            ),
+            ("MARKET", 100.0, None, "MARKET orders should not include price"),
+            ("MARKET", None, 100.0, "MARKET orders should not include stop_price"),
+            ("MARKET", 100.0, 100.0, "MARKET orders should not include price"),
             ("LIMIT", None, None, "LIMIT orders require a price"),
             ("LIMIT", 100.0, 50.0, "LIMIT orders should not include stop_price"),
             ("STOP", None, None, "STOP orders require a stop_price"),
             ("STOP", 100.0, 50.0, "STOP orders should not include price"),
-            (
-                "STOP_LIMIT",
-                None,
-                50.0,
-                "STOP_LIMIT orders require both stop_price and price",
-            ),
-            (
-                "STOP_LIMIT",
-                100.0,
-                None,
-                "STOP_LIMIT orders require both stop_price and price",
-            ),
+            ("STOP_LIMIT", None, 50.0, "STOP_LIMIT orders require a price"),
+            ("STOP_LIMIT", 100.0, None, "STOP_LIMIT orders require a stop_price"),
         ],
     )
     def test_price_validation_errors(


### PR DESCRIPTION
## Summary

- Replace repetitive if/elif dispatch logic in `_build_equity_order_spec()` and `_build_option_order_spec()` with lookup table approach
- Net reduction of 39 lines (81 added, 120 deleted)
- Makes adding new order types easier and reduces code duplication

## Changes

**Equity orders**: 8-entry lookup table keyed by `(order_type, instruction)` → `(builder_func, needs_price, needs_stop_price)`

**Option orders**: 4-entry lookup table keyed by `instruction` → `(market_builder, limit_builder)`

**Tests**: Updated error message expectations to match the cleaner, more specific messages from the refactored validation logic

## Before/After

Before: ~70 lines of nested if/elif/else for each function
After: ~35 lines with table lookup + unified validation