### PR TITLE
ci: add Python 3.13 and 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.10
-          - 3.11
-          - 3.12
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Add Python 3.13 and 3.14 to the CI test matrix
- Also quote existing version numbers to prevent YAML parsing issues (e.g., `3.10` being parsed as `3.1`)