### PR TITLE
feat: add trailing stop order support

### DIFF
--- a/src/schwab_mcp/tools/order_helpers.py
+++ b/src/schwab_mcp/tools/order_helpers.py
@@ -259,3 +259,25 @@ def option_sell_to_close_limit(
         .set_price(price)
         .add_option_leg(OptionInstruction.SELL_TO_CLOSE, symbol, quantity)
     )
+
+
+def equity_trailing_stop(
+    symbol,
+    quantity,
+    instruction,
+    stop_price_offset,
+    stop_price_link_type="VALUE",
+    duration=Duration.DAY,
+    session=Session.NORMAL,
+):
+    """
+    Returns a pre-filled OrderBuilder for an equity trailing stop order.
+    """
+    return (
+        __equity_base_builder(session, duration)
+        .set_order_type(OrderType.TRAILING_STOP)
+        .set_stop_price_offset(stop_price_offset)
+        .set_stop_price_link_type(stop_price_link_type)
+        .set_stop_price_link_basis("LAST")
+        .add_equity_leg(instruction, symbol, quantity)
+    )


### PR DESCRIPTION
## Summary

- Add `place_equity_trailing_stop_order` tool for placing trailing stop orders
- Add `build_equity_trailing_stop_order_spec` for complex order composition (OCO, triggers)
- Uses sensible defaults to keep the API simple for LLMs: `trail_type=VALUE` (dollars), always tracks `LAST` price

## Details

Trailing stop orders adjust the stop price as the stock price moves favorably. This PR adds support with a minimal parameter set:

| Parameter | Required | Description |
|-----------|----------|-------------|
| `account_hash` | Yes | Account hash |
| `symbol` | Yes | Stock symbol |
| `quantity` | Yes | Number of shares |
| `instruction` | Yes | BUY or SELL |
| `trail_offset` | Yes | Trailing amount (dollars or percent) |
| `trail_type` | No | VALUE (default, dollars) or PERCENT |
| `session` | No | NORMAL (default) |
| `duration` | No | DAY (default) |

The `trail_price_basis` is hardcoded to `LAST` to reduce cognitive load for MCP clients.

## Testing

- 12 new unit tests for trailing stop order validation
- All 104 tests pass
- Tested live with opencode - works!