### PR TITLE
chore: add Renovate configuration for Python dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard"
+  ],
+  "labels": ["dependencies"],
+  "minimumReleaseAge": "7 days",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on wednesday"]
+  },
+  "packageRules": [
+    {
+      "matchManagers": ["pip_requirements", "pip-compile", "poetry", "pep621"],
+      "groupName": "python dependencies"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds Renovate bot configuration for automated dependency management
- Groups Python dependencies together for cleaner PRs
- Enforces 7-day stabilization period for new releases before updating
- Schedules weekly lockfile maintenance on Wednesday mornings

## Configuration highlights

| Setting | Value |
|---------|-------|
| Minimum release age | 7 days |
| Lockfile maintenance | Wednesday before 9am |
| Python dep grouping | ✅ Enabled |
| Dependency dashboard | ✅ Enabled |