### PR TITLE
test: add shared fixtures in conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from schwab.client import AsyncClient
+
+from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
+from schwab_mcp.context import SchwabContext, SchwabServerContext
+
+
+class DummyApprovalManager(ApprovalManager):
+    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
+        return ApprovalDecision.APPROVED
+
+
+def make_ctx(client: Any) -> SchwabContext:
+    lifespan_context = SchwabServerContext(
+        client=cast(AsyncClient, client),
+        approval_manager=DummyApprovalManager(),
+    )
+    request_context = SimpleNamespace(lifespan_context=lifespan_context)
+    return SchwabContext.model_construct(
+        _request_context=cast(Any, request_context),
+        _fastmcp=None,
+    )
+
+
+def run(coro: Any) -> Any:
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def ctx_factory():
+    return make_ctx
+
+
+@pytest.fixture
+def fake_call_capture():
+    captured: dict[str, Any] = {}
+
+    async def fake_call(func, *args, **kwargs):
+        captured["func"] = func
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    return captured, fake_call

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,18 +1,11 @@
-import asyncio
 import datetime
 from enum import Enum
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from schwab.client import AsyncClient
 from schwab_mcp.tools import history
-from schwab_mcp.context import SchwabContext, SchwabServerContext
-from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
-
-class DummyApprovalManager(ApprovalManager):
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
-        return ApprovalDecision.APPROVED
+from conftest import make_ctx, run
 
 
 class DummyHistoryClient:
@@ -27,22 +20,6 @@ class DummyHistoryClient:
 
     async def get_price_history_every_minute(self, *args, **kwargs):
         return None
-
-
-def run(coro):
-    return asyncio.run(coro)
-
-
-def make_ctx(client: Any) -> SchwabContext:
-    lifespan_context = SchwabServerContext(
-        client=cast(AsyncClient, client),
-        approval_manager=DummyApprovalManager(),
-    )
-    request_context = SimpleNamespace(lifespan_context=lifespan_context)
-    return SchwabContext.model_construct(
-        _request_context=cast(Any, request_context),
-        _fastmcp=None,
-    )
 
 
 def test_get_advanced_price_history_normalizes_inputs(monkeypatch):

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,18 +1,10 @@
-import asyncio
 import datetime
 from enum import Enum
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from schwab.client import AsyncClient
 from schwab_mcp.tools import options
-from schwab_mcp.context import SchwabContext, SchwabServerContext
-from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
-
-class DummyApprovalManager(ApprovalManager):
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
-        return ApprovalDecision.APPROVED
+from conftest import make_ctx, run
 
 
 class DummyOptionsClient:
@@ -31,22 +23,6 @@ class DummyOptionsClient:
 
     async def get_option_expiration_chain(self, *args, **kwargs):
         return None
-
-
-def run(coro):
-    return asyncio.run(coro)
-
-
-def make_ctx(client: Any) -> SchwabContext:
-    lifespan_context = SchwabServerContext(
-        client=cast(AsyncClient, client),
-        approval_manager=DummyApprovalManager(),
-    )
-    request_context = SimpleNamespace(lifespan_context=lifespan_context)
-    return SchwabContext.model_construct(
-        _request_context=cast(Any, request_context),
-        _fastmcp=None,
-    )
 
 
 def test_get_advanced_option_chain_parses_and_maps_parameters(monkeypatch):

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1,18 +1,10 @@
-import asyncio
 import datetime
 from enum import Enum
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from schwab.client import AsyncClient
-from schwab_mcp.context import SchwabContext, SchwabServerContext
 from schwab_mcp.tools import orders
-from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
-
-class DummyApprovalManager(ApprovalManager):
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
-        return ApprovalDecision.APPROVED
+from conftest import make_ctx, run
 
 
 class DummyOrdersClient:
@@ -24,22 +16,6 @@ class DummyOrdersClient:
 
     async def get_orders_for_account(self, *args, **kwargs):
         return None
-
-
-def run(coro):
-    return asyncio.run(coro)
-
-
-def make_ctx(client: Any) -> SchwabContext:
-    lifespan_context = SchwabServerContext(
-        client=cast(AsyncClient, client),
-        approval_manager=DummyApprovalManager(),
-    )
-    request_context = SimpleNamespace(lifespan_context=lifespan_context)
-    return SchwabContext.model_construct(
-        _request_context=cast(Any, request_context),
-        _fastmcp=None,
-    )
 
 
 def test_get_orders_maps_single_status_and_dates(monkeypatch):

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -1,17 +1,9 @@
-import asyncio
 from enum import Enum
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from schwab.client import AsyncClient
 from schwab_mcp.tools import quotes
-from schwab_mcp.context import SchwabContext, SchwabServerContext
-from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
-
-class DummyApprovalManager(ApprovalManager):
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
-        return ApprovalDecision.APPROVED
+from conftest import make_ctx, run
 
 
 class DummyQuotesClient:
@@ -20,22 +12,6 @@ class DummyQuotesClient:
 
     async def get_quotes(self, *args, **kwargs):
         return None
-
-
-def run(coro):
-    return asyncio.run(coro)
-
-
-def make_ctx(client: Any) -> SchwabContext:
-    lifespan_context = SchwabServerContext(
-        client=cast(AsyncClient, client),
-        approval_manager=DummyApprovalManager(),
-    )
-    request_context = SimpleNamespace(lifespan_context=lifespan_context)
-    return SchwabContext.model_construct(
-        _request_context=cast(Any, request_context),
-        _fastmcp=None,
-    )
 
 
 def test_get_quotes_parses_symbols_and_fields(monkeypatch):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,19 +1,11 @@
-import asyncio
 import datetime
 from enum import Enum
-from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
-from schwab.client import AsyncClient
-from schwab_mcp.context import SchwabContext, SchwabServerContext
 from schwab_mcp.tools import tools
 from schwab_mcp.tools import options as options_tools
-from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
-
-class DummyApprovalManager(ApprovalManager):
-    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
-        return ApprovalDecision.APPROVED
+from conftest import make_ctx, run
 
 
 class DummyToolsClient:
@@ -41,22 +33,6 @@ class DummyToolsClient:
 
     async def get_instruments(self, *args, **kwargs):
         return None
-
-
-def run(coro):
-    return asyncio.run(coro)
-
-
-def make_ctx(client: Any) -> SchwabContext:
-    lifespan_context = SchwabServerContext(
-        client=cast(AsyncClient, client),
-        approval_manager=DummyApprovalManager(),
-    )
-    request_context = SimpleNamespace(lifespan_context=lifespan_context)
-    return SchwabContext.model_construct(
-        _request_context=cast(Any, request_context),
-        _fastmcp=None,
-    )
 
 
 def test_get_market_hours_handles_string_inputs(monkeypatch):


### PR DESCRIPTION
## Summary
- Add `tests/conftest.py` with shared test fixtures (`DummyApprovalManager`, `make_ctx`, `run`)
- Update 5 test files to import from the shared module instead of duplicating code
- Net reduction of ~70 lines of boilerplate

## Details
The test suite had identical copies of `DummyApprovalManager`, `make_ctx()`, and `run()` in multiple files. This consolidates them into pytest's standard `conftest.py` pattern.

**Files updated:**
- `tests/test_tools.py`
- `tests/test_orders.py`
- `tests/test_options.py`
- `tests/test_quotes.py`
- `tests/test_history.py`

**Note:** `test_approval_wrapping.py` was left unchanged as it uses a specialized `make_ctx` that returns additional components for testing approval recording behavior.

## Testing
- All 144 tests pass ✅
- Lint (`ruff check`) passes ✅
- Type check (`pyright`) passes ✅