### PR TITLE
fix(auth): ignore browser open errors

### DIFF
--- a/src/schwab_mcp/auth.py
+++ b/src/schwab_mcp/auth.py
@@ -219,8 +219,11 @@ def client_from_login_flow(
                 + "this method with interactive=False to skip this input."
             )
 
-        controller = auth.webbrowser.get(requested_browser)
-        controller.open(auth_context.authorization_url)
+        try:
+            controller = auth.webbrowser.get(requested_browser)
+            controller.open(auth_context.authorization_url)
+        except Exception:
+            pass
 
         # Wait for a response
         now = auth.__TIME_TIME()


### PR DESCRIPTION
Treat browser launch as best-effort to avoid failures when no runnable browser is available.