### PR TITLE
fix(auth): drop login prompt

### DIFF
--- a/src/schwab_mcp/auth.py
+++ b/src/schwab_mcp/auth.py
@@ -214,11 +214,6 @@ def client_from_login_flow(
             )
             print()
 
-            input(
-                "Press ENTER to open the browser. Note you can call "
-                + "this method with interactive=False to skip this input."
-            )
-
         try:
             controller = auth.webbrowser.get(requested_browser)
             controller.open(auth_context.authorization_url)


### PR DESCRIPTION
The login flow no longer waits for stdin before opening the authorization URL. This avoids EOF errors in headless sessions that do not have a TTY.