### PR TITLE
refactor(technical): extract common parameter type aliases

### DIFF
--- a/src/schwab_mcp/tools/technical/base.py
+++ b/src/schwab_mcp/tools/technical/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import datetime as _dt
 from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, cast
+from typing import Annotated, Any, Iterable, Mapping, TypeAlias, cast
 
 import pandas as pd
 
@@ -18,6 +18,39 @@ __all__ = [
     "frame_to_json",
     "ensure_columns",
     "pandas_ta",
+    "Symbol",
+    "Interval",
+    "StartTime",
+    "EndTime",
+    "Points",
+]
+
+Symbol: TypeAlias = Annotated[str, "Symbol of the security"]
+
+Interval: TypeAlias = Annotated[
+    str,
+    "Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w.",
+]
+
+StartTime: TypeAlias = Annotated[
+    str | None,
+    (
+        "Optional ISO-8601 timestamp for the first candle used in the calculation. "
+        "Defaults to enough history based on the requested parameters."
+    ),
+]
+
+EndTime: TypeAlias = Annotated[
+    str | None,
+    "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
+]
+
+Points: TypeAlias = Annotated[
+    int | None,
+    (
+        "Limit the number of indicator values returned. Defaults to the primary "
+        "length parameter. Use a larger number to inspect more history."
+    ),
 ]
 
 

--- a/src/schwab_mcp/tools/technical/momentum.py
+++ b/src/schwab_mcp/tools/technical/momentum.py
@@ -9,6 +9,11 @@ from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType
 
 from .base import (
+    EndTime,
+    Interval,
+    Points,
+    StartTime,
+    Symbol,
     ensure_columns,
     fetch_price_frame,
     frame_to_json,
@@ -21,30 +26,12 @@ __all__ = ["register"]
 
 async def rsi(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute the RSI"] = 14,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        (
-            "Optional ISO-8601 timestamp for the first candle used in the calculation. "
-            "Defaults to enough history based on the requested length."
-        ),
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of RSI values returned. Defaults to the requested length. "
-            "Use a larger number to inspect more history."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the Relative Strength Index (RSI) for Schwab price history."""
 
@@ -93,32 +80,14 @@ async def rsi(
 
 async def stoch(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     k_length: Annotated[int, "Number of periods used to compute %K"] = 14,
     d_length: Annotated[int, "Smoothing periods for %D"] = 3,
     smooth_k: Annotated[int, "Smoothing applied to %K before %D"] = 3,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        (
-            "Optional ISO-8601 timestamp for the first candle used in the calculation. "
-            "Defaults to enough history based on the requested lengths."
-        ),
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of stochastic oscillator values returned. Defaults to "
-            "k_length. Use a larger number to inspect more history."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the stochastic oscillator (%K and %D) for Schwab price history."""
 

--- a/src/schwab_mcp/tools/technical/moving_average.py
+++ b/src/schwab_mcp/tools/technical/moving_average.py
@@ -8,7 +8,16 @@ from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType
 
-from .base import fetch_price_frame, pandas_ta, series_to_json
+from .base import (
+    EndTime,
+    Interval,
+    Points,
+    StartTime,
+    Symbol,
+    fetch_price_frame,
+    pandas_ta,
+    series_to_json,
+)
 
 __all__ = ["register"]
 
@@ -75,30 +84,12 @@ async def _moving_average(
 
 async def sma(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute the SMA"] = 20,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        (
-            "Optional ISO-8601 timestamp for the first candle used in the calculation. "
-            "Defaults to enough history based on the requested length."
-        ),
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of SMA values returned. Defaults to the requested length. "
-            "Use a larger number to inspect more history."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute a simple moving average for Schwab price history."""
 
@@ -117,30 +108,12 @@ async def sma(
 
 async def ema(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute the EMA"] = 20,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        (
-            "Optional ISO-8601 timestamp for the first candle used in the calculation. "
-            "Defaults to enough history based on the requested length."
-        ),
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of EMA values returned. Defaults to the requested length. "
-            "Use a larger number to inspect more history."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute an exponential moving average for Schwab price history."""
 

--- a/src/schwab_mcp/tools/technical/overlays.py
+++ b/src/schwab_mcp/tools/technical/overlays.py
@@ -9,6 +9,11 @@ from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType
 
 from .base import (
+    EndTime,
+    Interval,
+    Points,
+    StartTime,
+    Symbol,
     ensure_columns,
     fetch_price_frame,
     frame_to_json,
@@ -21,27 +26,12 @@ __all__ = ["register"]
 
 async def vwap(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int | None, "Optional period applied to VWAP"] = None,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of VWAP values returned. Defaults to the requested length "
-            "when provided, otherwise 30."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the Volume Weighted Average Price (VWAP)."""
 
@@ -105,30 +95,16 @@ async def vwap(
 
 async def pivot_points(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     method: Annotated[
         str,
         "Pivot calculation method (standard, fibonacci, camarilla, woodie, demark).",
     ] = "standard",
     lookback: Annotated[int | None, "Number of prior periods to consider"] = None,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of pivot levels returned. Defaults to lookback or 10 if unset."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute pivot point support and resistance levels."""
 
@@ -184,26 +160,14 @@ async def pivot_points(
 
 async def bollinger_bands(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute the middle band"] = 20,
     std_dev: Annotated[float, "Standard deviation multiplier"] = 2.0,
     ma_mode: Annotated[str, "Moving average mode (e.g. sma, ema)"] = "sma",
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        ("Limit the number of band values returned. Defaults to the requested length."),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute Bollinger Bands for Schwab price history."""
 

--- a/src/schwab_mcp/tools/technical/trend.py
+++ b/src/schwab_mcp/tools/technical/trend.py
@@ -9,6 +9,11 @@ from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType
 
 from .base import (
+    EndTime,
+    Interval,
+    Points,
+    StartTime,
+    Symbol,
     ensure_columns,
     fetch_price_frame,
     frame_to_json,
@@ -21,29 +26,14 @@ __all__ = ["register"]
 
 async def macd(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     fast_length: Annotated[int, "Number of fast EMA periods"] = 12,
     slow_length: Annotated[int, "Number of slow EMA periods"] = 26,
     signal_length: Annotated[int, "Signal line EMA periods"] = 9,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        (
-            "Limit the number of MACD values returned. Defaults to the slow_length. "
-            "Use a larger number to inspect more history."
-        ),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the Moving Average Convergence Divergence (MACD) indicator."""
 
@@ -99,24 +89,12 @@ async def macd(
 
 async def atr(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute ATR"] = 14,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        ("Limit the number of ATR values returned. Defaults to the requested length."),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the Average True Range (ATR) for Schwab price history."""
 
@@ -168,24 +146,12 @@ async def atr(
 
 async def adx(
     ctx: SchwabContext,
-    symbol: Annotated[str, "Symbol of the security"],
+    symbol: Symbol,
     length: Annotated[int, "Number of periods used to compute ADX"] = 14,
-    interval: Annotated[
-        str,
-        ("Price interval. Supported values: 1m, 5m, 10m, 15m, 30m, 1d, 1w."),
-    ] = "1d",
-    start: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the first candle used in the calculation.",
-    ] = None,
-    end: Annotated[
-        str | None,
-        "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
-    ] = None,
-    points: Annotated[
-        int | None,
-        ("Limit the number of ADX values returned. Defaults to the requested length."),
-    ] = None,
+    interval: Interval = "1d",
+    start: StartTime = None,
+    end: EndTime = None,
+    points: Points = None,
 ) -> JSONType:
     """Compute the Average Directional Index (ADX) for Schwab price history."""
 


### PR DESCRIPTION
## Summary

- Define `Symbol`, `Interval`, `StartTime`, `EndTime`, and `Points` type aliases in `base.py`
- Update all 11 technical indicator functions across 5 modules to use the shared aliases
- Net reduction of 116 lines of duplicated parameter definitions

## Why

Every indicator function duplicated identical `Annotated[...]` definitions for common parameters (symbol, interval, start/end timestamps, points limit). This caused:

- Unnecessary verbosity (~40 lines of boilerplate per module)
- Risk of inconsistent descriptions across tools
- More maintenance burden when updating parameter docs

The type aliases centralize these definitions while preserving the MCP tool parameter descriptions.