### PR TITLE
refactor(tools): consolidate duplicate date parsing logic

### DIFF
--- a/src/schwab_mcp/tools/history.py
+++ b/src/schwab_mcp/tools/history.py
@@ -3,16 +3,11 @@
 from collections.abc import Callable
 from typing import Annotated, Any
 
-import datetime
 from mcp.server.fastmcp import FastMCP
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.tools.utils import JSONType, call
-
-
-def _parse_iso_datetime(value: str | None) -> datetime.datetime | None:
-    return datetime.datetime.fromisoformat(value) if value is not None else None
+from schwab_mcp.tools.utils import JSONType, call, parse_datetime
 
 
 async def _get_price_history(
@@ -28,8 +23,8 @@ async def _get_price_history(
     client = ctx.price_history
     method = getattr(client, method_name)
 
-    start_dt = _parse_iso_datetime(start_datetime)
-    end_dt = _parse_iso_datetime(end_datetime)
+    start_dt = parse_datetime(start_datetime)
+    end_dt = parse_datetime(end_datetime)
 
     return await call(
         method,
@@ -89,8 +84,8 @@ async def get_advanced_price_history(
     """
     client = ctx.price_history
 
-    start_dt = _parse_iso_datetime(start_datetime)
-    end_dt = _parse_iso_datetime(end_datetime)
+    start_dt = parse_datetime(start_datetime)
+    end_dt = parse_datetime(end_datetime)
 
     # Normalize enum-like strings
     period_type_enum = (

--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -7,20 +7,10 @@ from mcp.server.fastmcp import FastMCP
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.tools.utils import JSONType, call
+from schwab_mcp.tools.utils import JSONType, call, parse_date
 
 
 _EXPIRATION_WINDOW_DAYS = 60
-
-
-def _parse_date(value: str | datetime.date | None) -> datetime.date | None:
-    if value is None:
-        return None
-    if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
-        return value
-    if isinstance(value, datetime.datetime):
-        return value.date()
-    return datetime.datetime.strptime(value, "%Y-%m-%d").date()
 
 
 def _normalize_expiration_window(
@@ -76,8 +66,8 @@ async def get_option_chain(
     client = ctx.options
 
     from_date_obj, to_date_obj = _normalize_expiration_window(
-        _parse_date(from_date),
-        _parse_date(to_date),
+        parse_date(from_date),
+        parse_date(to_date),
     )
 
     return await call(
@@ -151,8 +141,8 @@ async def get_advanced_option_chain(
     """
     client = ctx.options
 
-    from_date_obj = _parse_date(from_date)
-    to_date_obj = _parse_date(to_date)
+    from_date_obj = parse_date(from_date)
+    to_date_obj = parse_date(to_date)
     from_date_obj, to_date_obj = _normalize_expiration_window(
         from_date_obj,
         to_date_obj,

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from typing import Annotated, Any, cast
 
 import copy
-import datetime
 from mcp.server.fastmcp import FastMCP
 from schwab.utils import (
     AccountHashMismatchException,
@@ -18,6 +17,7 @@ from schwab.orders.generic import OrderBuilder
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
+from schwab_mcp.tools.utils import parse_date
 from schwab_mcp.tools.order_helpers import (
     equity_buy_limit,
     equity_buy_market,
@@ -244,14 +244,8 @@ async def get_orders(
     """
     client = ctx.orders
 
-    from_date_obj = None
-    to_date_obj = None
-
-    if from_date is not None:
-        from_date_obj = datetime.datetime.strptime(from_date, "%Y-%m-%d").date()
-
-    if to_date is not None:
-        to_date_obj = datetime.datetime.strptime(to_date, "%Y-%m-%d").date()
+    from_date_obj = parse_date(from_date)
+    to_date_obj = parse_date(to_date)
 
     # Map status to enums; support list via 'statuses'
     kwargs: dict[str, Any] = {

--- a/src/schwab_mcp/tools/tools.py
+++ b/src/schwab_mcp/tools/tools.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import FastMCP
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.tools.utils import JSONType, call
+from schwab_mcp.tools.utils import JSONType, call, parse_date
 
 
 async def get_datetime() -> str:
@@ -40,9 +40,7 @@ async def get_market_hours(
 
     market_enums = [client.MarketHours.Market[m.upper()] for m in markets]
 
-    date_obj = None
-    if date is not None:
-        date_obj = datetime.datetime.strptime(date, "%Y-%m-%d").date()
+    date_obj = parse_date(date)
 
     return await call(client.get_market_hours, market_enums, date=date_obj)
 

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -2,12 +2,11 @@
 from collections.abc import Callable
 from typing import Annotated, Any
 
-import datetime
 from mcp.server.fastmcp import FastMCP
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.tools.utils import JSONType, call
+from schwab_mcp.tools.utils import JSONType, call, parse_date
 
 
 async def get_transactions(
@@ -33,14 +32,8 @@ async def get_transactions(
     """
     client = ctx.transactions
 
-    start_date_obj = None
-    end_date_obj = None
-
-    if start_date is not None:
-        start_date_obj = datetime.datetime.strptime(start_date, "%Y-%m-%d").date()
-
-    if end_date is not None:
-        end_date_obj = datetime.datetime.strptime(end_date, "%Y-%m-%d").date()
+    start_date_obj = parse_date(start_date)
+    end_date_obj = parse_date(end_date)
 
     transaction_type_enums = None
     if transaction_type is not None:

--- a/src/schwab_mcp/tools/utils.py
+++ b/src/schwab_mcp/tools/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeAlias
 
@@ -24,6 +25,37 @@ class SchwabAPIError(Exception):
         super().__init__(
             f"Schwab API request failed; status={status_code}; url={url}; body={body}"
         )
+
+
+def parse_date(value: str | datetime.date | None) -> datetime.date | None:
+    """Parse a date from string, date, datetime, or None.
+
+    Args:
+        value: A date string in YYYY-MM-DD format, a date object,
+               a datetime object, or None.
+
+    Returns:
+        A date object, or None if the input was None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime.date) and not isinstance(value, datetime.datetime):
+        return value
+    if isinstance(value, datetime.datetime):
+        return value.date()
+    return datetime.datetime.strptime(value, "%Y-%m-%d").date()
+
+
+def parse_datetime(value: str | None) -> datetime.datetime | None:
+    """Parse a datetime from an ISO format string or None.
+
+    Args:
+        value: An ISO format datetime string, or None.
+
+    Returns:
+        A datetime object, or None if the input was None.
+    """
+    return datetime.datetime.fromisoformat(value) if value is not None else None
 
 
 async def call(
@@ -73,4 +105,11 @@ async def call(
         raise ValueError("Expected JSON response from Schwab endpoint") from exc
 
 
-__all__ = ["call", "JSONType", "SchwabAPIError", "ResponseHandler"]
+__all__ = [
+    "call",
+    "JSONType",
+    "SchwabAPIError",
+    "ResponseHandler",
+    "parse_date",
+    "parse_datetime",
+]

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -241,9 +241,3 @@ class TestSimplePriceHistoryFunctions:
 
         assert captured["kwargs"]["need_extended_hours_data"] is True
         assert captured["kwargs"]["need_previous_close"] is False
-
-
-class TestParseIsoDatetime:
-    def test_returns_none_for_none_input(self):
-        result = history._parse_iso_datetime(None)
-        assert result is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from schwab_mcp.tools.utils import SchwabAPIError, call
+from schwab_mcp.tools.utils import SchwabAPIError, call, parse_date, parse_datetime
 
 
 class MockResponse:
@@ -223,3 +223,46 @@ class TestJSONParseFailure:
             run(call(fake_endpoint))
 
         assert exc_info.value.__cause__ is not None
+
+
+class TestParseDateFunction:
+    def test_parse_date_with_none(self):
+        assert parse_date(None) is None
+
+    def test_parse_date_with_string(self):
+        import datetime
+
+        result = parse_date("2024-03-15")
+        assert result == datetime.date(2024, 3, 15)
+
+    def test_parse_date_with_date(self):
+        import datetime
+
+        input_date = datetime.date(2024, 3, 15)
+        result = parse_date(input_date)
+        assert result == input_date
+        assert result is input_date
+
+    def test_parse_date_with_datetime(self):
+        import datetime
+
+        input_datetime = datetime.datetime(2024, 3, 15, 10, 30)
+        result = parse_date(input_datetime)
+        assert result == datetime.date(2024, 3, 15)
+
+
+class TestParseDatetimeFunction:
+    def test_parse_datetime_with_none(self):
+        assert parse_datetime(None) is None
+
+    def test_parse_datetime_with_iso_string(self):
+        import datetime
+
+        result = parse_datetime("2024-03-15T10:30:00")
+        assert result == datetime.datetime(2024, 3, 15, 10, 30)
+
+    def test_parse_datetime_with_date_only_string(self):
+        import datetime
+
+        result = parse_datetime("2024-03-15")
+        assert result == datetime.datetime(2024, 3, 15, 0, 0)


### PR DESCRIPTION
## Summary

Consolidates 5+ duplicate date/datetime parsing implementations across the tools module into two shared helper functions in `utils.py`.

## Changes

### New Helpers
- **`parse_date()`** - Handles `str | date | datetime | None` → `date | None`
  - Accepts YYYY-MM-DD strings, date objects, datetime objects, or None
  - Returns date object or None
- **`parse_datetime()`** - Handles `str | None` → `datetime | None`
  - Accepts ISO format datetime strings or None
  - Returns datetime object or None

### Files Updated
- ✅ `src/schwab_mcp/tools/utils.py` - Added helpers with type hints and docstrings
- ✅ `tests/test_utils.py` - Added 7 comprehensive unit tests
- ✅ `src/schwab_mcp/tools/history.py` - Removed `_parse_iso_datetime()`, use shared helper
- ✅ `src/schwab_mcp/tools/options.py` - Removed `_parse_date()`, use shared helper
- ✅ `src/schwab_mcp/tools/orders.py` - Replaced inline parsing with shared helper
- ✅ `src/schwab_mcp/tools/transactions.py` - Replaced inline parsing with shared helper
- ✅ `src/schwab_mcp/tools/tools.py` - Replaced inline parsing with shared helper

### Cleanup
- Removed unused `datetime` imports from refactored files

## Benefits

- **DRY Principle**: Eliminates code duplication across 5+ files
- **Maintainability**: Centralizes date parsing logic in one place
- **Type Safety**: Proper type hints on all helpers
- **Tested**: Comprehensive unit tests for edge cases
- **Backward Compatible**: 100% behavioral compatibility maintained

## Verification

✅ All 259 tests pass  
✅ Zero type errors (pyright)  
✅ Zero lint errors (ruff)  
✅ No duplicate parsing functions remain

```bash
uv run pytest          # 259 passed
uv run pyright         # 0 errors
uv run ruff check .    # All checks passed
```

## Testing

The new helpers are thoroughly tested:
- `parse_date(None)` → `None`
- `parse_date("2024-03-15")` → `date(2024, 3, 15)`
- `parse_date(date(2024, 3, 15))` → `date(2024, 3, 15)` (passthrough)
- `parse_date(datetime(2024, 3, 15, 10, 30))` → `date(2024, 3, 15)` (extracts date)
- `parse_datetime(None)` → `None`
- `parse_datetime("2024-03-15T10:30:00")` → `datetime(2024, 3, 15, 10, 30)`
- `parse_datetime("2024-03-15")` → `datetime(2024, 3, 15, 0, 0)` (date-only strings)

All existing tests continue to pass, confirming behavioral compatibility.