### PR TITLE
fix(tools): use Transactions (plural) for transaction type enum

### DIFF
--- a/src/schwab_mcp/tools/_protocols.py
+++ b/src/schwab_mcp/tools/_protocols.py
@@ -157,12 +157,12 @@ class TransactionTypeNamespace(Protocol):
     def __getitem__(self, key: str) -> Any: ...
 
 
-class TransactionNamespace(Protocol):
+class TransactionsNamespace(Protocol):
     TransactionType: TransactionTypeNamespace
 
 
 class TransactionsClient(Protocol):
-    Transaction: TransactionNamespace
+    Transactions: TransactionsNamespace
 
     def get_transactions(self, account_hash: str, **kwargs: Any) -> Awaitable[Any]: ...
 

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -40,7 +40,7 @@ async def get_transactions(
         if isinstance(transaction_type, str):
             transaction_type = [t.strip() for t in transaction_type.split(",")]
         transaction_type_enums = [
-            client.Transaction.TransactionType[t.upper()] for t in transaction_type
+            client.Transactions.TransactionType[t.upper()] for t in transaction_type
         ]
 
     # Corrected function name to client.get_transactions and keyword arg to transaction_types

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -11,7 +11,7 @@ from conftest import make_ctx, run
 
 
 class DummyTransactionsClient:
-    class Transaction:
+    class Transactions:
         TransactionType = Enum(
             "TransactionType",
             "TRADE DIVIDEND_OR_INTEREST ACH_RECEIPT ACH_DISBURSEMENT",
@@ -87,7 +87,7 @@ class TestGetTransactions:
         )
 
         assert captured["kwargs"]["transaction_types"] == [
-            client.Transaction.TransactionType.TRADE
+            client.Transactions.TransactionType.TRADE
         ]
 
     def test_maps_comma_separated_transaction_types(
@@ -106,8 +106,8 @@ class TestGetTransactions:
         )
 
         assert captured["kwargs"]["transaction_types"] == [
-            client.Transaction.TransactionType.TRADE,
-            client.Transaction.TransactionType.DIVIDEND_OR_INTEREST,
+            client.Transactions.TransactionType.TRADE,
+            client.Transactions.TransactionType.DIVIDEND_OR_INTEREST,
         ]
 
     def test_maps_list_of_transaction_types(
@@ -126,8 +126,8 @@ class TestGetTransactions:
         )
 
         assert captured["kwargs"]["transaction_types"] == [
-            client.Transaction.TransactionType.ACH_RECEIPT,
-            client.Transaction.TransactionType.ACH_DISBURSEMENT,
+            client.Transactions.TransactionType.ACH_RECEIPT,
+            client.Transactions.TransactionType.ACH_DISBURSEMENT,
         ]
 
     def test_passes_symbol_filter(self, monkeypatch, ctx, client, fake_call_factory):
@@ -166,7 +166,7 @@ class TestGetTransactions:
         assert captured["kwargs"]["start_date"] == datetime.date(2024, 3, 1)
         assert captured["kwargs"]["end_date"] == datetime.date(2024, 3, 31)
         assert captured["kwargs"]["transaction_types"] == [
-            client.Transaction.TransactionType.TRADE
+            client.Transactions.TransactionType.TRADE
         ]
         assert captured["kwargs"]["symbol"] == "AAPL"
 


### PR DESCRIPTION
## Summary

- Fix `get_transactions` failing with `'AsyncClient' object has no attribute 'Transaction'` when `transaction_type` filter is provided
- Update protocol class and tests to match schwab-py's actual API

## Root Cause

The schwab-py library exposes the TransactionType enum under `client.Transactions.TransactionType` (plural), not `client.Transaction.TransactionType` (singular).

## Changes

- `transactions.py`: Use `client.Transactions.TransactionType` instead of `client.Transaction.TransactionType`
- `_protocols.py`: Update `TransactionsClient` protocol to use `Transactions` attribute
- `test_transactions.py`: Update mock class and assertions to use plural form

Fixes #69