### PR TITLE
Fix AttributeError in pivot_points tool

### DIFF
--- a/src/schwab_mcp/tools/technical/overlays.py
+++ b/src/schwab_mcp/tools/technical/overlays.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Annotated, Any
 
+import pandas as pd
 from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -23,6 +24,85 @@ from .base import (
 )
 
 __all__ = ["register"]
+
+# pandas_ta_classic (the pinned indicator library, aliased as `pandas_ta` in
+# .base) has no `pivot_points` attribute under any version we've run against
+# (confirmed empty on 0.3.59 — no top-level function, no submodule), so the
+# indicator is computed directly below instead. vwap/bbands still use
+# pandas_ta since those genuinely exist there.
+
+_PIVOT_METHODS = ("standard", "fibonacci", "camarilla", "woodie", "demark")
+
+
+def _compute_pivot_points(
+    frame: pd.DataFrame, *, method: str, lookback: int | None
+) -> pd.DataFrame:
+    """Compute floor-trader pivot levels from the prior period's H/L/C."""
+    method = method.lower()
+    if method not in _PIVOT_METHODS:
+        raise ValueError(
+            f"Unsupported pivot method '{method}'. "
+            f"Choose from: {', '.join(_PIVOT_METHODS)}."
+        )
+
+    window = lookback if lookback and lookback > 0 else 1
+    high = frame["high"].rolling(window=window).max().shift(1)
+    low = frame["low"].rolling(window=window).min().shift(1)
+    close = frame["close"].shift(1)
+    diff = high - low
+
+    result = pd.DataFrame(index=frame.index)
+
+    if method == "standard":
+        pp = (high + low + close) / 3
+        result["PP"] = pp
+        result["R1"] = 2 * pp - low
+        result["S1"] = 2 * pp - high
+        result["R2"] = pp + diff
+        result["S2"] = pp - diff
+        result["R3"] = high + 2 * (pp - low)
+        result["S3"] = low - 2 * (high - pp)
+    elif method == "fibonacci":
+        pp = (high + low + close) / 3
+        result["PP"] = pp
+        result["R1"] = pp + 0.382 * diff
+        result["S1"] = pp - 0.382 * diff
+        result["R2"] = pp + 0.618 * diff
+        result["S2"] = pp - 0.618 * diff
+        result["R3"] = pp + diff
+        result["S3"] = pp - diff
+    elif method == "camarilla":
+        result["PP"] = (high + low + close) / 3
+        result["R1"] = close + diff * 1.1 / 12
+        result["S1"] = close - diff * 1.1 / 12
+        result["R2"] = close + diff * 1.1 / 6
+        result["S2"] = close - diff * 1.1 / 6
+        result["R3"] = close + diff * 1.1 / 4
+        result["S3"] = close - diff * 1.1 / 4
+        result["R4"] = close + diff * 1.1 / 2
+        result["S4"] = close - diff * 1.1 / 2
+    elif method == "woodie":
+        pp = (high + low + 2 * close) / 4
+        result["PP"] = pp
+        result["R1"] = 2 * pp - low
+        result["S1"] = 2 * pp - high
+        result["R2"] = pp + diff
+        result["S2"] = pp - diff
+    else:  # demark
+        if "open" not in frame.columns:
+            raise ValueError(
+                "demark pivot method requires an 'open' column in price history."
+            )
+        open_ = frame["open"].shift(1)
+        x = high + low + 2 * close  # close == open case
+        x = x.mask(close < open_, high + 2 * low + close)
+        x = x.mask(close > open_, 2 * high + low + close)
+        pp = x / 4
+        result["PP"] = pp
+        result["R1"] = x / 2 - low
+        result["S1"] = x / 2 - high
+
+    return result
 
 
 async def vwap(
@@ -109,12 +189,8 @@ async def pivot_points(
     return await compute_frame_indicator(
         ctx,
         symbol,
-        indicator_fn=lambda frame: pandas_ta.pivot_points(
-            high=frame["high"],
-            low=frame["low"],
-            close=frame["close"],
-            method=method,
-            lookback=lookback,
+        indicator_fn=lambda frame: _compute_pivot_points(
+            frame, method=method, lookback=lookback
         ),
         indicator_name="pivot_points",
         interval=interval,

--- a/tests/test_technical_tools.py
+++ b/tests/test_technical_tools.py
@@ -252,41 +252,59 @@ def test_vwap_requires_positive_volume(monkeypatch, dummy_ctx, ohlcv_data):
 
 
 def test_pivot_points_returns_levels(monkeypatch, dummy_ctx, ohlcv_data):
+    # pandas_ta_classic has no pivot_points implementation (confirmed empty on
+    # 0.3.59), so this indicator is computed directly rather than delegated —
+    # no pandas_ta monkeypatch needed here, unlike the other overlay tools.
     frame, metadata = ohlcv_data
 
     async def fake_fetch(ctx, symbol, **kwargs):
         return frame, metadata
 
-    def fake_pivots(high, low, close, *, method="standard", lookback=None):
-        data = pd.DataFrame(
-            {
-                "pp": pd.Series([10, 11, 12, 13, 14, 15], index=close.index),
-                "r1": pd.Series([11, 12, 13, 14, 15, 16], index=close.index),
-                "s1": pd.Series([9, 10, 11, 12, 13, 14], index=close.index),
-            }
-        )
-        return data
-
     monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
-    monkeypatch.setattr(
-        overlays,
-        "pandas_ta",
-        SimpleNamespace(
-            pivot_points=fake_pivots,
-            vwap=lambda *args, **kwargs: None,
-            bbands=lambda *args, **kwargs: None,
-        ),
-    )
 
     result = run_tool(
         overlays.pivot_points(
-            dummy_ctx, "HOOD", method="standard", lookback=5, points=2
+            dummy_ctx, "HOOD", method="standard", lookback=1, points=2
         )
     )
 
     values = result["values"]
     assert len(values) == 2
-    assert {"timestamp", "pp", "r1", "s1"}.issubset(values[-1].keys())
+    assert {"timestamp", "PP", "R1", "S1", "R2", "S2", "R3", "S3"}.issubset(
+        values[-1].keys()
+    )
+
+    high = frame["high"].shift(1)
+    low = frame["low"].shift(1)
+    close = frame["close"].shift(1)
+    expected_pp = ((high + low + close) / 3).dropna().tail(2).to_numpy()
+    for row, expected in zip(values, expected_pp):
+        assert row["PP"] == pytest.approx(float(expected))
+
+
+def test_pivot_points_rejects_unknown_method(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="Unsupported pivot method"):
+        run(overlays.pivot_points(dummy_ctx, "HOOD", method="bogus"))
+
+
+def test_pivot_points_demark_requires_open_column(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+    frame = frame.drop(columns=["open"])
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="requires an 'open' column"):
+        run(overlays.pivot_points(dummy_ctx, "HOOD", method="demark"))
 
 
 def test_bollinger_bands_returns_values(monkeypatch, dummy_ctx, price_data):


### PR DESCRIPTION
## Summary
- `pandas_ta_classic` (pinned at 0.3.59) has no `pivot_points` function anywhere — top-level or submodule — so every call to the `pivot_points` MCP tool raised `AttributeError: module 'pandas_ta_classic' has no attribute 'pivot_points'`
- Replaces the `pandas_ta_classic` delegation with a direct floor-trader pivot calculation (standard, fibonacci, camarilla, woodie, demark) computed from prior-period H/L/C, plugged into the existing `compute_frame_indicator` contract so the rest of the tool (bars, points, metadata) is unchanged
- Updates `test_pivot_points_returns_levels` (previously mocked a `pandas_ta.pivot_points` that doesn't exist) and adds two new tests for the unsupported-method and demark-without-open-column error paths

Fixes #105

## Test plan
- [x] `uv run pytest tests/test_technical_tools.py -q` — 23 passed
- [x] `uv run ruff check` / `uv run ruff format --check` on changed files — clean
- [x] Verified all 5 pivot methods against synthetic OHLC data in a local deployment before writing this PR