### PR TITLE
feat(tools): compact option chain responses by default

### DIFF
--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -12,6 +12,55 @@ from schwab_mcp.tools.utils import JSONType, call, parse_date
 
 _EXPIRATION_WINDOW_DAYS = 60
 
+_COMPACT_CONTRACT_FIELDS = frozenset(
+    {
+        "strike",
+        "bid",
+        "ask",
+        "last",
+        "mark",
+        "bidSize",
+        "askSize",
+        "volume",
+        "openInterest",
+        "delta",
+        "gamma",
+        "theta",
+        "vega",
+        "rho",
+        "impliedVolatility",
+        "inTheMoney",
+        "expirationDate",
+        "daysToExpiration",
+        "expirationType",
+    }
+)
+
+
+def _prune_contract(contract: dict[str, JSONType]) -> dict[str, JSONType]:
+    return {k: v for k, v in contract.items() if k in _COMPACT_CONTRACT_FIELDS}
+
+
+def _prune_option_chain(payload: JSONType) -> JSONType:
+    """Prune contract fields in-place. Safe because ``call()`` always returns
+    a freshly-parsed JSON object with no other references."""
+    if not isinstance(payload, dict):
+        return payload
+    for map_key in ("callExpDateMap", "putExpDateMap"):
+        exp_map = payload.get(map_key)
+        if not isinstance(exp_map, dict):
+            continue
+        for _date_key, strikes in exp_map.items():
+            if not isinstance(strikes, dict):
+                continue
+            for strike_key, contracts in strikes.items():
+                if not isinstance(contracts, list):
+                    continue
+                strikes[strike_key] = [
+                    _prune_contract(c) if isinstance(c, dict) else c for c in contracts
+                ]
+    return payload
+
 
 def _normalize_expiration_window(
     from_date: datetime.date | None,
@@ -57,11 +106,16 @@ async def get_option_chain(
         str | datetime.date | None,
         "End date for option expiration ('YYYY-MM-DD' or datetime.date)",
     ] = None,
+    verbose: Annotated[
+        bool,
+        "Return all raw contract fields instead of the compact default. Compact mode keeps price/greeks/liquidity fields only.",
+    ] = False,
 ) -> JSONType:
     """
     Returns option chain data (strikes, expirations, prices) for a symbol. Use for standard chains.
     Params: symbol, contract_type (CALL/PUT/ALL), strike_count (default 25), include_quotes (bool), from_date (YYYY-MM-DD), to_date (YYYY-MM-DD).
     Limit data returned using strike_count and date parameters. When both dates are omitted the tool defaults to the next 60 calendar days to avoid oversized responses.
+    By default returns compact per-contract fields only; pass verbose=True for the full raw payload.
     """
     client = ctx.options
 
@@ -70,7 +124,7 @@ async def get_option_chain(
         parse_date(to_date),
     )
 
-    return await call(
+    result = await call(
         client.get_option_chain,
         symbol,
         contract_type=client.Options.ContractType[contract_type.upper()]
@@ -81,6 +135,7 @@ async def get_option_chain(
         from_date=from_date_obj,
         to_date=to_date_obj,
     )
+    return result if verbose else _prune_option_chain(result)
 
 
 async def get_advanced_option_chain(
@@ -133,11 +188,16 @@ async def get_advanced_option_chain(
     option_type: Annotated[
         str | None, "Filter option type: STANDARD, NON_STANDARD, ALL (default)"
     ] = None,
+    verbose: Annotated[
+        bool,
+        "Return all raw contract fields instead of the compact default. Compact mode keeps price/greeks/liquidity fields only.",
+    ] = False,
 ) -> JSONType:
     """
     Returns advanced option chain data with strategies, filters, and theoretical calculations. Use for complex analysis.
     Params: symbol, contract_type, strike_count, include_quotes, strategy (SINGLE/ANALYTICAL/etc.), interval, strike, strike_range (ITM/NTM/etc.), from/to_date, volatility/underlying_price/interest_rate/days_to_expiration (for ANALYTICAL), exp_month, option_type (STANDARD/NON_STANDARD/ALL).
     Limit data returned using strike_count and date parameters. When both dates are omitted the tool defaults to the next 60 calendar days to avoid oversized responses.
+    By default returns compact per-contract fields only; pass verbose=True for the full raw payload.
     """
     client = ctx.options
 
@@ -148,7 +208,7 @@ async def get_advanced_option_chain(
         to_date_obj,
     )
 
-    return await call(
+    result = await call(
         client.get_option_chain,
         symbol,
         contract_type=client.Options.ContractType[contract_type.upper()]
@@ -173,6 +233,7 @@ async def get_advanced_option_chain(
         else None,
         option_type=client.Options.Type[option_type.upper()] if option_type else None,
     )
+    return result if verbose else _prune_option_chain(result)
 
 
 async def get_option_expiration_chain(

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -14,7 +14,6 @@ import asyncio
 from typing import Any
 
 
-
 class TestFakeCallFactory:
     """Tests for fake_call_factory fixture."""
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,5 +1,6 @@
 import datetime
 from enum import Enum
+from typing import Any
 
 from schwab_mcp.tools import options
 
@@ -79,3 +80,140 @@ def test_get_advanced_option_chain_parses_and_maps_parameters(
     assert kwargs["days_to_expiration"] == 30
     assert kwargs["exp_month"] is client.Options.ExpirationMonth.JAN
     assert kwargs["option_type"] is client.Options.Type.STANDARD
+
+
+# ---------------------------------------------------------------------------
+# _prune_contract / _prune_option_chain helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_CONTRACT = {
+    "strike": 420.0,
+    "bid": 1.5,
+    "ask": 1.6,
+    "last": 1.55,
+    "mark": 1.55,
+    "bidSize": 10,
+    "askSize": 20,
+    "volume": 500,
+    "openInterest": 1000,
+    "delta": -0.35,
+    "gamma": 0.05,
+    "theta": -0.02,
+    "vega": 0.1,
+    "rho": 0.01,
+    "impliedVolatility": 0.25,
+    "inTheMoney": False,
+    "expirationDate": "2024-06-21",
+    "daysToExpiration": 30,
+    "expirationType": "R",
+    # Extra fields that should be stripped
+    "description": "SPY Jun 21 2024 420 Put",
+    "exchangeName": "OPR",
+    "settlementType": " ",
+    "deliverableNote": "",
+}
+
+
+def test_prune_contract_keeps_compact_fields():
+    pruned = options._prune_contract(_SAMPLE_CONTRACT)
+    assert set(pruned.keys()) == options._COMPACT_CONTRACT_FIELDS
+    assert pruned["strike"] == 420.0
+    assert pruned["delta"] == -0.35
+    assert "description" not in pruned
+    assert "exchangeName" not in pruned
+
+
+def _make_chain_payload(contract: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "symbol": "SPY",
+        "callExpDateMap": {
+            "2024-06-21:30": {
+                "420.0": [contract],
+            }
+        },
+        "putExpDateMap": {
+            "2024-06-21:30": {
+                "420.0": [contract],
+            }
+        },
+    }
+
+
+def test_prune_option_chain_default_prunes_contracts(monkeypatch, fake_call_factory):
+    _, fake_call = fake_call_factory(return_value=_make_chain_payload(_SAMPLE_CONTRACT))
+    monkeypatch.setattr(options, "call", fake_call)
+
+    client = DummyOptionsClient()
+    ctx = make_ctx(client)
+    result = run(options.get_option_chain(ctx, "SPY"))
+
+    assert isinstance(result, dict)
+    call_contract = result["callExpDateMap"]["2024-06-21:30"]["420.0"][0]
+    put_contract = result["putExpDateMap"]["2024-06-21:30"]["420.0"][0]
+    assert set(call_contract.keys()) == options._COMPACT_CONTRACT_FIELDS
+    assert set(put_contract.keys()) == options._COMPACT_CONTRACT_FIELDS
+    assert "description" not in call_contract
+
+
+def test_prune_option_chain_verbose_returns_raw(monkeypatch, fake_call_factory):
+    payload = _make_chain_payload(_SAMPLE_CONTRACT)
+    _, fake_call = fake_call_factory(return_value=payload)
+    monkeypatch.setattr(options, "call", fake_call)
+
+    client = DummyOptionsClient()
+    ctx = make_ctx(client)
+    result = run(options.get_option_chain(ctx, "SPY", verbose=True))
+
+    assert isinstance(result, dict)
+    call_contract = result["callExpDateMap"]["2024-06-21:30"]["420.0"][0]
+    assert "description" in call_contract
+
+
+def test_prune_option_chain_advanced_default_prunes(monkeypatch, fake_call_factory):
+    _, fake_call = fake_call_factory(return_value=_make_chain_payload(_SAMPLE_CONTRACT))
+    monkeypatch.setattr(options, "call", fake_call)
+
+    client = DummyOptionsClient()
+    ctx = make_ctx(client)
+    result = run(options.get_advanced_option_chain(ctx, "SPY"))
+
+    assert isinstance(result, dict)
+    call_contract = result["callExpDateMap"]["2024-06-21:30"]["420.0"][0]
+    assert set(call_contract.keys()) == options._COMPACT_CONTRACT_FIELDS
+
+
+def test_prune_option_chain_advanced_verbose_returns_raw(
+    monkeypatch, fake_call_factory
+):
+    payload = _make_chain_payload(_SAMPLE_CONTRACT)
+    _, fake_call = fake_call_factory(return_value=payload)
+    monkeypatch.setattr(options, "call", fake_call)
+
+    client = DummyOptionsClient()
+    ctx = make_ctx(client)
+    result = run(options.get_advanced_option_chain(ctx, "SPY", verbose=True))
+
+    call_contract = result["callExpDateMap"]["2024-06-21:30"]["420.0"][0]
+    assert "description" in call_contract
+
+
+def test_prune_option_chain_non_dict_payload_passthrough():
+    assert options._prune_option_chain("not a dict") == "not a dict"
+    assert options._prune_option_chain(None) is None
+    assert options._prune_option_chain([1, 2, 3]) == [1, 2, 3]
+
+
+def test_prune_option_chain_missing_exp_maps_passthrough():
+    payload = {"symbol": "SPY", "status": "SUCCESS"}
+    result = options._prune_option_chain(payload)
+    assert result == {"symbol": "SPY", "status": "SUCCESS"}
+
+
+def test_prune_option_chain_malformed_exp_map_no_raise():
+    payload = {
+        "callExpDateMap": "oops",
+        "putExpDateMap": {"2024-06-21:30": "not-a-dict"},
+    }
+    # Should not raise, return payload unchanged for bad shapes
+    result = options._prune_option_chain(payload)
+    assert result is payload


### PR DESCRIPTION
## Summary

- Add compact-by-default responses for `get_option_chain` and `get_advanced_option_chain` to cut token usage for LLM clients consuming this server.
- Each returned contract now keeps only ~19 high-value fields (strike, bid/ask/last/mark, sizes, volume, open interest, greeks, implied volatility, in-the-money flag, and expiration info) instead of the 40+ raw fields Schwab returns.
- A new `verbose` parameter (default `False`) opts back into the full raw payload when needed.

## Why

Option chains are the largest responses this server returns. With `strike_count` defaulting to 25 and typical multi-expiration queries, each chain can contain hundreds of contract objects, and most of the raw Schwab fields (deliverables, exchange metadata, settlement type, multiplier, etc.) aren't useful for typical price/greeks/liquidity analysis. Pruning them by default meaningfully reduces the size of tool results without losing anything an LLM would normally use.

## Testing

- Added tests covering default pruning, `verbose=True` passthrough, and defensive handling of missing or malformed `callExpDateMap`/`putExpDateMap` shapes.
- `uv run ruff check`, `uv run pyright`, and `uv run pytest` all pass (309 tests).