### PR TITLE
feat(tools): compact account, quote, and order responses by default

### DIFF
--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -9,6 +9,84 @@ from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType, call
 
+_COMPACT_ACCOUNT_FIELDS = frozenset(
+    {"type", "accountNumber", "roundTrips", "isDayTrader"}
+)
+
+_COMPACT_BALANCE_FIELDS = frozenset(
+    {
+        "equity",
+        "buyingPower",
+        "cashBalance",
+        "cashAvailableForTrading",
+        "liquidationValue",
+    }
+)
+
+
+def _prune_position(position: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    instrument = position.get("instrument")
+    if isinstance(instrument, dict):
+        symbol = instrument.get("symbol")
+        if symbol is not None:
+            result["symbol"] = symbol
+    # Net quantity: positive = long, negative = short
+    long_qty = position.get("longQuantity", 0)
+    short_qty = position.get("shortQuantity", 0)
+    if not isinstance(long_qty, (int, float)):
+        long_qty = 0
+    if not isinstance(short_qty, (int, float)):
+        short_qty = 0
+    result["quantity"] = long_qty - short_qty
+    market_value = position.get("marketValue")
+    if market_value is not None:
+        result["marketValue"] = market_value
+    average_price = position.get("averagePrice")
+    if average_price is not None:
+        result["averagePrice"] = average_price
+    unrealized_pl = position.get("currentDayProfitLoss")
+    if unrealized_pl is not None:
+        result["unrealizedPL"] = unrealized_pl
+    return result
+
+
+def _prune_securities_account(sec_account: dict[str, Any]) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        k: v for k, v in sec_account.items() if k in _COMPACT_ACCOUNT_FIELDS
+    }
+    current_balances = sec_account.get("currentBalances")
+    if not isinstance(current_balances, dict):
+        current_balances = {}
+    result["currentBalances"] = {
+        k: v for k, v in current_balances.items() if k in _COMPACT_BALANCE_FIELDS
+    }
+    if "positions" in sec_account:
+        positions = sec_account["positions"]
+        if isinstance(positions, list):
+            result["positions"] = [_prune_position(p) for p in positions]
+        else:
+            result["positions"] = positions
+    return result
+
+
+def _prune_account_response(payload: JSONType) -> JSONType:
+    if isinstance(payload, list):
+        return [
+            {"securitiesAccount": _prune_securities_account(item["securitiesAccount"])}
+            if isinstance(item, dict)
+            and "securitiesAccount" in item
+            and isinstance(item["securitiesAccount"], dict)
+            else item
+            for item in payload
+        ]
+    if isinstance(payload, dict) and "securitiesAccount" in payload:
+        sec = payload["securitiesAccount"]
+        if isinstance(sec, dict):
+            return {"securitiesAccount": _prune_securities_account(sec)}
+        return payload
+    return payload
+
 
 async def get_account_numbers(
     ctx: SchwabContext,
@@ -21,47 +99,71 @@ async def get_account_numbers(
 
 async def get_accounts(
     ctx: SchwabContext,
+    verbose: Annotated[
+        bool,
+        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
     Returns balances/info for all linked accounts (funds, cash, margin). Does not return hashes; use get_account_numbers first.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped); pass verbose=True for the full raw payload.
     """
-    return await call(ctx.accounts.get_accounts)
+    result = await call(ctx.accounts.get_accounts)
+    return result if verbose else _prune_account_response(result)
 
 
 async def get_accounts_with_positions(
     ctx: SchwabContext,
+    verbose: Annotated[
+        bool,
+        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
     Returns balances, info, and positions (holdings, cost, gain/loss) for all linked accounts. Does not return hashes; use get_account_numbers first.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
     """
-    return await call(
+    result = await call(
         ctx.accounts.get_accounts,
         fields=[ctx.accounts.Account.Fields.POSITIONS],
     )
+    return result if verbose else _prune_account_response(result)
 
 
 async def get_account(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
+    verbose: Annotated[
+        bool,
+        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
     Returns balance/info for a specific account via account_hash (from get_account_numbers). Includes funds, cash, margin info.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped); pass verbose=True for the full raw payload.
     """
-    return await call(ctx.accounts.get_account, account_hash)
+    result = await call(ctx.accounts.get_account, account_hash)
+    return result if verbose else _prune_account_response(result)
 
 
 async def get_account_with_positions(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
+    verbose: Annotated[
+        bool,
+        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
     Returns balance, info, and positions for a specific account via account_hash. Includes holdings, quantity, cost basis, unrealized gain/loss.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
     """
-    return await call(
+    result = await call(
         ctx.accounts.get_account,
         account_hash,
         fields=[ctx.accounts.Account.Fields.POSITIONS],
     )
+    return result if verbose else _prune_account_response(result)
 
 
 async def get_user_preferences(

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -40,6 +40,70 @@ from schwab_mcp.tools.order_helpers import (
 from schwab_mcp.tools.utils import JSONType, ResponseHandler, call
 
 
+_COMPACT_ORDER_TOP_FIELDS = frozenset(
+    {
+        "orderId",
+        "status",
+        "quantity",
+        "filledQuantity",
+        "remainingQuantity",
+        "price",
+        "stopPrice",
+        "orderType",
+        "session",
+        "duration",
+        "orderStrategyType",
+        "enteredTime",
+        "closeTime",
+    }
+)
+
+
+def _order_legs_summary(order: dict[str, Any]) -> list[dict[str, Any]]:
+    legs = order.get("orderLegCollection", [])
+    result = []
+    for leg in legs:
+        if not isinstance(leg, dict):
+            continue
+        instrument = leg.get("instrument")
+        symbol = instrument.get("symbol") if isinstance(instrument, dict) else None
+        result.append(
+            {
+                "symbol": symbol,
+                "instruction": leg.get("instruction"),
+                "quantity": leg.get("quantity"),
+            }
+        )
+    return result
+
+
+def _prune_order(order: JSONType) -> JSONType:
+    if not isinstance(order, dict):
+        return order
+    result: dict[str, JSONType] = {
+        k: v for k, v in order.items() if k in _COMPACT_ORDER_TOP_FIELDS
+    }
+    order_legs = order.get("orderLegCollection")
+    if isinstance(order_legs, list) and order_legs:
+        legs_summary = _order_legs_summary(order)
+        if legs_summary:
+            result["legs"] = legs_summary
+    child_strategies = order.get("childOrderStrategies")
+    if isinstance(child_strategies, list) and child_strategies:
+        result["childOrderStrategies"] = [
+            _prune_order(child) for child in child_strategies
+        ]
+    return result
+
+
+def _prune_orders(payload: JSONType) -> JSONType:
+    return (
+        [_prune_order(o) for o in payload]
+        if isinstance(payload, list)
+        else _prune_order(payload)
+    )
+
+
 # Internal helper function to apply session and duration settings
 def _apply_order_settings(order_spec, session: str | None, duration: str | None):
     """Internal helper to apply session and duration to an order spec builder."""
@@ -212,12 +276,21 @@ async def get_order(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
     order_id: Annotated[str, "Order ID to get details for"],
+    verbose: Annotated[
+        bool,
+        "Return the full raw order payload (routing metadata, full nested child orders, execution activity) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
-    Returns details for a specific order (ID, status, price, quantity, execution details). Params: account_hash, order_id.
+    Returns details for a specific order. By default returns compact fields only
+    (orderId, status, quantity, filledQuantity, remainingQuantity, price, stopPrice,
+    orderType, session, duration, orderStrategyType, enteredTime, closeTime, legs
+    summary, and recursively-pruned childOrderStrategies); pass verbose=True for
+    the full raw payload. Params: account_hash, order_id.
     """
     client = ctx.orders
-    return await call(client.get_order, order_id=order_id, account_hash=account_hash)
+    result = await call(client.get_order, order_id=order_id, account_hash=account_hash)
+    return result if verbose else _prune_order(result)
 
 
 async def get_orders(
@@ -235,9 +308,17 @@ async def get_orders(
         list[str] | str | None,
         "Filter by order status (e.g., WORKING, FILLED, CANCELED). See full list below.",
     ] = None,
+    verbose: Annotated[
+        bool,
+        "Return the full raw order payload (routing metadata, full nested child orders, execution activity) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
-    Returns order history for an account. Filter by date range (max 60 days past) and status.
+    Returns order history for an account. By default returns compact fields only
+    (orderId, status, quantity, filledQuantity, remainingQuantity, price, stopPrice,
+    orderType, session, duration, orderStrategyType, enteredTime, closeTime, legs
+    summary, and recursively-pruned childOrderStrategies); pass verbose=True for
+    the full raw payload. Filter by date range (max 60 days past) and status.
     Params: account_hash, max_results, from_date (YYYY-MM-DD), to_date (YYYY-MM-DD), status (list/str).
     Status options: AWAITING_PARENT_ORDER, AWAITING_CONDITION, AWAITING_STOP_CONDITION, AWAITING_MANUAL_REVIEW, ACCEPTED, AWAITING_UR_OUT, PENDING_ACTIVATION, QUEUED, WORKING, REJECTED, PENDING_CANCEL, CANCELED, PENDING_REPLACE, REPLACED, FILLED, EXPIRED, NEW, AWAITING_RELEASE_TIME, PENDING_ACKNOWLEDGEMENT, PENDING_RECALL.
     Use tomorrow's date as to_date for today's orders. Use WORKING/PENDING_ACTIVATION for open orders.
@@ -257,7 +338,7 @@ async def get_orders(
         if isinstance(status, str):
             # Single status: direct API call
             kwargs["status"] = client.Order.Status[status.upper()]
-            return await call(
+            result: JSONType = await call(
                 client.get_orders_for_account,
                 account_hash,
                 **kwargs,
@@ -269,24 +350,26 @@ async def get_orders(
             seen_order_ids: set[str] = set()
             for s in status:
                 kwargs["status"] = client.Order.Status[s.upper()]
-                result = await call(
+                partial = await call(
                     client.get_orders_for_account,
                     account_hash,
                     **kwargs,
                 )
-                if result:
-                    for order in cast(list[Any], result):
+                if partial:
+                    for order in cast(list[Any], partial):
                         order_id = str(order.get("orderId", ""))
                         if order_id and order_id not in seen_order_ids:
                             seen_order_ids.add(order_id)
                             all_orders.append(order)
-            return all_orders if all_orders else []
+            result = all_orders if all_orders else []
+    else:
+        result = await call(
+            client.get_orders_for_account,
+            account_hash,
+            **kwargs,
+        )
 
-    return await call(
-        client.get_orders_for_account,
-        account_hash,
-        **kwargs,
-    )
+    return result if verbose else _prune_orders(result)
 
 
 async def cancel_order(
@@ -678,8 +761,12 @@ async def place_bracket_order(
     quantity: Annotated[int, "Number of shares to trade"],
     entry_instruction: Annotated[str, "BUY or SELL for the entry order"],
     entry_type: Annotated[str, "Entry order type: MARKET, LIMIT, STOP, or STOP_LIMIT"],
-    profit_price: Annotated[float | None, "Take-profit limit price (optional if loss_price provided)"] = None,
-    loss_price: Annotated[float | None, "Stop-loss trigger price (optional if profit_price provided)"] = None,
+    profit_price: Annotated[
+        float | None, "Take-profit limit price (optional if loss_price provided)"
+    ] = None,
+    loss_price: Annotated[
+        float | None, "Stop-loss trigger price (optional if profit_price provided)"
+    ] = None,
     entry_price: Annotated[
         float | None, "Required for LIMIT entry; Limit price for STOP_LIMIT entry"
     ] = None,
@@ -711,9 +798,7 @@ async def place_bracket_order(
     """
     # Validate that at least one exit price is provided
     if profit_price is None and loss_price is None:
-        raise ValueError(
-            "At least one of profit_price or loss_price must be provided"
-        )
+        raise ValueError("At least one of profit_price or loss_price must be provided")
 
     # Validate entry instruction
     client = ctx.orders
@@ -763,13 +848,17 @@ async def place_bracket_order(
     if profit_price is not None and loss_price is not None:
         # Both prices: entry triggers OCO(profit, loss)
         oco_exit_order_builder = oco_builder(profit_order_builder, loss_order_builder)
-        bracket_order_builder = trigger_builder(entry_order_builder, oco_exit_order_builder)
+        bracket_order_builder = trigger_builder(
+            entry_order_builder, oco_exit_order_builder
+        )
     elif loss_price is not None:
         # Stop-loss only: entry triggers single stop order
         bracket_order_builder = trigger_builder(entry_order_builder, loss_order_builder)
     else:
         # Take-profit only: entry triggers single limit order
-        bracket_order_builder = trigger_builder(entry_order_builder, profit_order_builder)
+        bracket_order_builder = trigger_builder(
+            entry_order_builder, profit_order_builder
+        )
 
     # Build the final complex bracket order dictionary
     bracket_order_dict = cast(dict[str, Any], bracket_order_builder.build())

--- a/src/schwab_mcp/tools/quotes.py
+++ b/src/schwab_mcp/tools/quotes.py
@@ -9,6 +9,37 @@ from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType, call
 
 
+_COMPACT_QUOTE_FIELDS = (
+    "lastPrice",
+    "bidPrice",
+    "askPrice",
+    "mark",
+    "netChange",
+    "netPercentChange",
+    "highPrice",
+    "lowPrice",
+    "totalVolume",
+)
+
+
+def _prune_quote(symbol_key: str, entry: dict[str, JSONType]) -> dict[str, JSONType]:
+    result: dict[str, JSONType] = {"symbol": entry.get("symbol", symbol_key)}
+    quote_sub = entry.get("quote", {})
+    if isinstance(quote_sub, dict):
+        for k in _COMPACT_QUOTE_FIELDS:
+            if k in quote_sub:
+                result[k] = quote_sub[k]
+    return result
+
+
+def _prune_quotes(payload: JSONType) -> JSONType:
+    if not isinstance(payload, dict):
+        return payload
+    return {
+        k: _prune_quote(k, v) if isinstance(v, dict) else v for k, v in payload.items()
+    }
+
+
 async def get_quotes(
     ctx: SchwabContext,
     symbols: Annotated[
@@ -22,10 +53,15 @@ async def get_quotes(
     indicative: Annotated[
         bool | None, "True for indicative quotes (extended hours/futures)"
     ] = None,
+    verbose: Annotated[
+        bool,
+        "Return the full raw payload (quote/fundamental/reference/regular blocks) instead of the compact default.",
+    ] = False,
 ) -> JSONType:
     """
     Returns current market quotes for specified symbols (stocks, ETFs, indices, options).
     Params: symbols (list or comma-separated string), fields (list/str: QUOTE/FUNDAMENTAL/etc.), indicative (bool).
+    By default returns compact quote fields only (lastPrice, bidPrice, askPrice, mark, netChange, netPercentChange, highPrice, lowPrice, totalVolume); pass verbose=True for the full raw payload.
     """
     client = ctx.quotes
 
@@ -38,12 +74,13 @@ async def get_quotes(
             fields = [f.strip() for f in fields.split(",")]
         field_enums = [client.Quote.Fields[f.upper()] for f in fields]
 
-    return await call(
+    result = await call(
         client.get_quotes,
         symbols,
         fields=field_enums,
         indicative=indicative if indicative is not None else None,
     )
+    return result if verbose else _prune_quotes(result)
 
 
 _READ_ONLY_TOOLS = (get_quotes,)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -41,6 +41,48 @@ class DummyAccountClient:
         return None
 
 
+# ---------------------------------------------------------------------------
+# Sample raw payloads
+# ---------------------------------------------------------------------------
+
+_RAW_SEC_ACCOUNT = {
+    "type": "MARGIN",
+    "accountNumber": "123",
+    "roundTrips": 0,
+    "isDayTrader": False,
+    "currentBalances": {
+        "equity": 50000.0,
+        "buyingPower": 20000.0,
+        "cashBalance": 5000.0,
+        "cashAvailableForTrading": 4000.0,
+        "liquidationValue": 49000.0,
+        "maintenanceRequirement": 1000.0,  # should be stripped
+        "totalCash": 6000.0,  # should be stripped
+    },
+    "initialBalances": {"equity": 48000.0},  # should be dropped in compact
+    "projectedBalances": {"equity": 51000.0},  # should be dropped in compact
+}
+
+_RAW_POSITION = {
+    "longQuantity": 10,
+    "shortQuantity": 0,
+    "averagePrice": 150.0,
+    "currentDayProfitLoss": 100.0,
+    "currentDayProfitLossPercentage": 0.01,
+    "marketValue": 1550.0,
+    "maintenanceRequirement": 0.0,
+    "settledLongQuantity": 10,  # should be stripped
+    "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+}
+
+_RAW_SEC_ACCOUNT_WITH_POSITIONS = {**_RAW_SEC_ACCOUNT, "positions": [_RAW_POSITION]}
+
+_RAW_LIST_PAYLOAD = [{"securitiesAccount": _RAW_SEC_ACCOUNT}]
+_RAW_LIST_WITH_POSITIONS = [{"securitiesAccount": _RAW_SEC_ACCOUNT_WITH_POSITIONS}]
+_RAW_DICT_PAYLOAD = {"securitiesAccount": _RAW_SEC_ACCOUNT}
+_RAW_DICT_WITH_POSITIONS = {"securitiesAccount": _RAW_SEC_ACCOUNT_WITH_POSITIONS}
+
+
 class TestGetAccountNumbers:
     def test_calls_client_method(self, monkeypatch, fake_call_factory):
         captured, fake_call = fake_call_factory(
@@ -67,10 +109,43 @@ class TestGetAccounts:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_accounts(ctx))
+        result = run(account.get_accounts(ctx, verbose=True))
 
         assert result == [{"securitiesAccount": {"accountNumber": "123"}}]
         assert captured["func"].__name__ == "get_accounts"
+
+    def test_compact_default_strips_extra_fields(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts(ctx))
+
+        assert isinstance(result, list)
+        sec = result[0]["securitiesAccount"]
+        # identity fields kept
+        assert sec["accountNumber"] == "123"
+        assert sec["type"] == "MARGIN"
+        # initialBalances / projectedBalances dropped
+        assert "initialBalances" not in sec
+        assert "projectedBalances" not in sec
+        # only allowlisted balance fields
+        balances = sec["currentBalances"]
+        assert set(balances.keys()) <= account._COMPACT_BALANCE_FIELDS
+        assert "maintenanceRequirement" not in balances
+        assert "totalCash" not in balances
+        assert balances["equity"] == 50000.0
+
+    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts(ctx, verbose=True))
+
+        assert result is _RAW_LIST_PAYLOAD
 
 
 class TestGetAccountsWithPositions:
@@ -83,11 +158,44 @@ class TestGetAccountsWithPositions:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_accounts_with_positions(ctx))
+        result = run(account.get_accounts_with_positions(ctx, verbose=True))
 
         assert result == [{"securitiesAccount": {"positions": []}}]
         assert captured["func"].__name__ == "get_accounts"
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
+
+    def test_compact_default_prunes_positions(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts_with_positions(ctx))
+
+        assert isinstance(result, list)
+        sec = result[0]["securitiesAccount"]
+        assert "initialBalances" not in sec
+        assert "projectedBalances" not in sec
+        positions = sec["positions"]
+        assert len(positions) == 1
+        pos = positions[0]
+        assert pos["symbol"] == "AAPL"
+        assert pos["quantity"] == 10  # longQuantity 10 - shortQuantity 0
+        assert pos["marketValue"] == 1550.0
+        assert pos["averagePrice"] == 150.0
+        assert pos["unrealizedPL"] == 100.0
+        assert "settledLongQuantity" not in pos
+        assert "maintenanceRequirement" not in pos
+
+    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts_with_positions(ctx, verbose=True))
+
+        assert result is _RAW_LIST_WITH_POSITIONS
 
 
 class TestGetAccount:
@@ -100,11 +208,38 @@ class TestGetAccount:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account(ctx, "hash456"))
+        result = run(account.get_account(ctx, "hash456", verbose=True))
 
         assert result == {"securitiesAccount": {"accountNumber": "456"}}
         assert captured["func"].__name__ == "get_account"
         assert captured["args"] == ("hash456",)
+
+    def test_compact_default_strips_extra_fields(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account(ctx, "hash456"))
+
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountNumber"] == "123"
+        assert "initialBalances" not in sec
+        assert "projectedBalances" not in sec
+        balances = sec["currentBalances"]
+        assert set(balances.keys()) <= account._COMPACT_BALANCE_FIELDS
+        assert "maintenanceRequirement" not in balances
+
+    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account(ctx, "hash456", verbose=True))
+
+        assert result is _RAW_DICT_PAYLOAD
 
 
 class TestGetAccountWithPositions:
@@ -119,12 +254,44 @@ class TestGetAccountWithPositions:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account_with_positions(ctx, "hash789"))
+        result = run(account.get_account_with_positions(ctx, "hash789", verbose=True))
 
         assert result == {"securitiesAccount": {"positions": [{"symbol": "SPY"}]}}
         assert captured["func"].__name__ == "get_account"
         assert captured["args"] == ("hash789",)
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
+
+    def test_compact_default_prunes_positions(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account_with_positions(ctx, "hash789"))
+
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert "initialBalances" not in sec
+        assert "projectedBalances" not in sec
+        positions = sec["positions"]
+        assert len(positions) == 1
+        pos = positions[0]
+        assert pos["symbol"] == "AAPL"
+        assert pos["quantity"] == 10
+        assert pos["marketValue"] == 1550.0
+        assert pos["averagePrice"] == 150.0
+        assert pos["unrealizedPL"] == 100.0
+        assert "settledLongQuantity" not in pos
+
+    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account_with_positions(ctx, "hash789", verbose=True))
+
+        assert result is _RAW_DICT_WITH_POSITIONS
 
 
 class TestGetUserPreferences:
@@ -141,3 +308,107 @@ class TestGetUserPreferences:
 
         assert result == {"accounts": [{"displayAcctId": "...1234"}]}
         assert captured["func"].__name__ == "get_user_preferences"
+
+
+# ---------------------------------------------------------------------------
+# Edge case: net quantity with both longQuantity and shortQuantity nonzero
+# ---------------------------------------------------------------------------
+
+
+def test_prune_position_net_quantity_long_minus_short():
+    position = {
+        "longQuantity": 10,
+        "shortQuantity": 3,
+        "averagePrice": 200.0,
+        "currentDayProfitLoss": -50.0,
+        "marketValue": 1400.0,
+        "instrument": {"symbol": "TSLA", "assetType": "EQUITY"},
+    }
+    pruned = account._prune_position(position)
+    assert pruned["quantity"] == 7  # 10 - 3
+    assert pruned["symbol"] == "TSLA"
+    assert pruned["marketValue"] == 1400.0
+    assert pruned["unrealizedPL"] == -50.0
+
+
+# ---------------------------------------------------------------------------
+# Fix #2: _prune_position type guards for instrument / quantities
+# ---------------------------------------------------------------------------
+
+
+def test_prune_position_instrument_none_omits_symbol():
+    """When instrument is None (not a dict), symbol key must be absent."""
+    position = {"longQuantity": 5, "shortQuantity": 0, "instrument": None}
+    pruned = account._prune_position(position)
+    assert "symbol" not in pruned
+    assert pruned["quantity"] == 5
+
+
+def test_prune_position_instrument_missing_omits_symbol():
+    """When instrument key is absent entirely, symbol key must be absent."""
+    position = {"longQuantity": 2, "shortQuantity": 0}
+    pruned = account._prune_position(position)
+    assert "symbol" not in pruned
+    assert pruned["quantity"] == 2
+
+
+def test_prune_position_non_numeric_quantities_default_to_zero():
+    """Non-numeric longQuantity/shortQuantity must default to 0."""
+    position = {
+        "longQuantity": "ten",
+        "shortQuantity": None,
+        "instrument": {"symbol": "X"},
+    }
+    pruned = account._prune_position(position)
+    assert pruned["quantity"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Fix #3: _prune_securities_account guards for currentBalances / positions
+# ---------------------------------------------------------------------------
+
+
+def test_prune_securities_account_none_current_balances():
+    """currentBalances=None must produce an empty dict, not raise."""
+    sec = {
+        "type": "CASH",
+        "accountNumber": "999",
+        "currentBalances": None,
+    }
+    pruned = account._prune_securities_account(sec)
+    assert pruned["currentBalances"] == {}
+
+
+def test_prune_securities_account_positions_not_a_list_passthrough():
+    """When positions is not a list, it must be passed through unchanged."""
+    sec = {
+        "type": "CASH",
+        "accountNumber": "999",
+        "currentBalances": {},
+        "positions": {"unexpected": "dict"},
+    }
+    pruned = account._prune_securities_account(sec)
+    assert pruned["positions"] == {"unexpected": "dict"}
+
+
+# ---------------------------------------------------------------------------
+# Fix #4: _prune_account_response guards securitiesAccount type
+# ---------------------------------------------------------------------------
+
+
+def test_prune_account_response_securities_account_not_dict_passthrough():
+    """When securitiesAccount is not a dict, the original value must be kept."""
+    payload = {"securitiesAccount": "bad-value"}
+    result = account._prune_account_response(payload)
+    assert result == {"securitiesAccount": "bad-value"}
+
+
+def test_prune_account_response_list_item_securities_account_not_dict():
+    """In a list payload, items where securitiesAccount is not a dict pass through."""
+    payload = [{"securitiesAccount": None}, {"securitiesAccount": _RAW_SEC_ACCOUNT}]
+    result = account._prune_account_response(payload)
+    assert isinstance(result, list)
+    # First item unchanged because securitiesAccount is not a dict
+    assert result[0] == {"securitiesAccount": None}
+    # Second item should be pruned normally
+    assert "currentBalances" in result[1]["securitiesAccount"]

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -124,6 +124,203 @@ class TestGetOrder:
         assert captured["kwargs"]["order_id"] == "order456"
 
 
+class TestGetOrderCompact:
+    _RAW_ORDER: dict[str, Any] = {
+        "orderId": "99",
+        "status": "FILLED",
+        "quantity": 10.0,
+        "filledQuantity": 10.0,
+        "remainingQuantity": 0.0,
+        "price": 1.5,
+        "stopPrice": None,
+        "orderType": "LIMIT",
+        "session": "NORMAL",
+        "duration": "DAY",
+        "orderStrategyType": "SINGLE",
+        "enteredTime": "2024-04-01T10:00:00Z",
+        "closeTime": "2024-04-01T10:01:00Z",
+        # noise fields
+        "requestedDestination": "AUTO",
+        "destinationLinkName": "ETMM",
+        "tag": "sometag",
+        "accountNumber": "abc123",
+        "complexOrderStrategyType": "NONE",
+        "cancelable": False,
+        "editable": False,
+        "orderActivityCollection": [
+            {
+                "activityType": "EXECUTION",
+                "executionLegs": [{"price": 1.5, "quantity": 10}],
+            }
+        ],
+        "orderLegCollection": [
+            {
+                "orderLegType": "EQUITY",
+                "legId": 1,
+                "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                "instruction": "BUY",
+                "positionEffect": "OPENING",
+                "quantity": 10.0,
+            }
+        ],
+        "childOrderStrategies": [
+            {
+                "orderId": "100",
+                "status": "WORKING",
+                "quantity": 10.0,
+                "filledQuantity": 0.0,
+                "remainingQuantity": 10.0,
+                "price": 2.0,
+                "stopPrice": None,
+                "orderType": "LIMIT",
+                "session": "NORMAL",
+                "duration": "GTC",
+                "orderStrategyType": "SINGLE",
+                "enteredTime": "2024-04-01T10:01:00Z",
+                "closeTime": None,
+                # noise
+                "requestedDestination": "AUTO",
+                "tag": "childtag",
+                "orderActivityCollection": [],
+                "orderLegCollection": [
+                    {
+                        "orderLegType": "EQUITY",
+                        "legId": 1,
+                        "instrument": {"symbol": "AAPL", "assetType": "EQUITY"},
+                        "instruction": "SELL",
+                        "positionEffect": "CLOSING",
+                        "quantity": 10.0,
+                    }
+                ],
+            }
+        ],
+    }
+
+    def test_compact_default_prunes_noise(self, monkeypatch):
+        async def fake_call(func, *args, **kwargs):
+            return dict(self._RAW_ORDER)
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        class DummyClient:
+            async def get_order(self, *args, **kwargs):
+                return None
+
+        ctx = make_ctx(DummyClient())
+        result = run(orders.get_order(ctx, "hash123", "99"))
+
+        assert isinstance(result, dict)
+        # Compact fields kept
+        assert result["orderId"] == "99"
+        assert result["status"] == "FILLED"
+        assert result["orderType"] == "LIMIT"
+        # Noise fields dropped
+        assert "requestedDestination" not in result
+        assert "destinationLinkName" not in result
+        assert "tag" not in result
+        assert "orderActivityCollection" not in result
+        assert "accountNumber" not in result
+        # legs summary present
+        assert result["legs"] == [
+            {"symbol": "AAPL", "instruction": "BUY", "quantity": 10.0}
+        ]
+        # child order also pruned
+        assert "childOrderStrategies" in result
+        child = result["childOrderStrategies"][0]
+        assert child["orderId"] == "100"
+        assert child["status"] == "WORKING"
+        assert "requestedDestination" not in child
+        assert "tag" not in child
+        assert "orderActivityCollection" not in child
+        assert child["legs"] == [
+            {"symbol": "AAPL", "instruction": "SELL", "quantity": 10.0}
+        ]
+
+    def test_verbose_returns_raw_payload(self, monkeypatch):
+        raw = dict(self._RAW_ORDER)
+
+        async def fake_call(func, *args, **kwargs):
+            return raw
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        class DummyClient:
+            async def get_order(self, *args, **kwargs):
+                return None
+
+        ctx = make_ctx(DummyClient())
+        result = run(orders.get_order(ctx, "hash123", "99", verbose=True))
+
+        assert result is raw
+        assert "requestedDestination" in result
+        assert "orderActivityCollection" in result
+
+
+class TestGetOrdersCompact:
+    def test_compact_default_prunes_list(self, monkeypatch):
+        raw_orders = [
+            {
+                "orderId": "1",
+                "status": "FILLED",
+                "quantity": 5.0,
+                "filledQuantity": 5.0,
+                "remainingQuantity": 0.0,
+                "price": 10.0,
+                "stopPrice": None,
+                "orderType": "LIMIT",
+                "session": "NORMAL",
+                "duration": "DAY",
+                "orderStrategyType": "SINGLE",
+                "enteredTime": "2024-04-01T10:00:00Z",
+                "closeTime": "2024-04-01T10:01:00Z",
+                # noise
+                "requestedDestination": "AUTO",
+                "tag": "noise",
+                "orderActivityCollection": [],
+                "orderLegCollection": [
+                    {
+                        "instrument": {"symbol": "MSFT"},
+                        "instruction": "BUY",
+                        "quantity": 5.0,
+                    }
+                ],
+            }
+        ]
+
+        async def fake_call(func, *args, **kwargs):
+            return raw_orders
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        ctx = make_ctx(DummyOrdersClient())
+        result = run(orders.get_orders(ctx, "hash123"))
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        order = result[0]
+        assert order["orderId"] == "1"
+        assert "requestedDestination" not in order
+        assert "tag" not in order
+        assert "orderActivityCollection" not in order
+        assert order["legs"] == [
+            {"symbol": "MSFT", "instruction": "BUY", "quantity": 5.0}
+        ]
+
+    def test_verbose_returns_raw_list(self, monkeypatch):
+        raw_orders = [{"orderId": "1", "status": "FILLED", "tag": "noise"}]
+
+        async def fake_call(func, *args, **kwargs):
+            return raw_orders
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        ctx = make_ctx(DummyOrdersClient())
+        result = run(orders.get_orders(ctx, "hash123", verbose=True))
+
+        assert result is raw_orders
+        assert result[0]["tag"] == "noise"
+
+
 class TestCancelOrder:
     def test_calls_client_with_correct_args(self, monkeypatch):
         captured: dict[str, Any] = {}
@@ -863,3 +1060,98 @@ class TestOrderResponseHandler:
         assert isinstance(payload, dict)
         assert "location" in payload
         assert "orderId" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Fix #5: _order_legs_summary type guards for non-dict legs / instrument
+# ---------------------------------------------------------------------------
+
+
+class TestOrderLegsSummaryTypeGuards:
+    def test_skips_non_dict_legs(self):
+        """Non-dict entries in orderLegCollection must be silently skipped."""
+        order: dict[str, Any] = {
+            "orderLegCollection": [
+                "not-a-dict",
+                42,
+                {"instrument": {"symbol": "AAPL"}, "instruction": "BUY", "quantity": 5},
+            ]
+        }
+        result = orders._order_legs_summary(order)
+        assert result == [{"symbol": "AAPL", "instruction": "BUY", "quantity": 5}]
+
+    def test_instrument_not_dict_yields_none_symbol(self):
+        """When instrument is not a dict, symbol must be None (not raise)."""
+        order: dict[str, Any] = {
+            "orderLegCollection": [
+                {"instrument": None, "instruction": "SELL", "quantity": 3},
+            ]
+        }
+        result = orders._order_legs_summary(order)
+        assert result == [{"symbol": None, "instruction": "SELL", "quantity": 3}]
+
+    def test_instrument_missing_yields_none_symbol(self):
+        """When instrument key is absent, symbol must be None."""
+        order: dict[str, Any] = {
+            "orderLegCollection": [
+                {"instruction": "BUY", "quantity": 10},
+            ]
+        }
+        result = orders._order_legs_summary(order)
+        assert result == [{"symbol": None, "instruction": "BUY", "quantity": 10}]
+
+
+# ---------------------------------------------------------------------------
+# Fix #6: _prune_order validates list types before processing
+# ---------------------------------------------------------------------------
+
+
+class TestPruneOrderTypeGuards:
+    def test_order_leg_collection_as_dict_not_processed(self):
+        """orderLegCollection that is a dict (not a list) must not add legs key."""
+        order: dict[str, Any] = {
+            "orderId": "1",
+            "status": "WORKING",
+            "orderLegCollection": {"unexpected": "dict"},
+        }
+        result = orders._prune_order(order)
+        assert isinstance(result, dict)
+        assert "legs" not in result.keys()
+
+    def test_child_order_strategies_as_dict_not_processed(self):
+        """childOrderStrategies that is a dict must not add childOrderStrategies key."""
+        order: dict[str, Any] = {
+            "orderId": "2",
+            "status": "WORKING",
+            "childOrderStrategies": {"unexpected": "dict"},
+        }
+        result = orders._prune_order(order)
+        assert isinstance(result, dict)
+        assert "childOrderStrategies" not in result.keys()
+
+    def test_empty_order_leg_collection_list_omits_legs_key(self):
+        """An empty orderLegCollection list must not add a legs key."""
+        order: dict[str, Any] = {
+            "orderId": "3",
+            "status": "FILLED",
+            "orderLegCollection": [],
+        }
+        result = orders._prune_order(order)
+        assert isinstance(result, dict)
+        assert "legs" not in result.keys()
+
+    def test_all_non_dict_legs_omits_legs_key(self):
+        """When all legs are non-dict, the resulting summary is empty, so legs key is omitted."""
+        order: dict[str, Any] = {
+            "orderId": "4",
+            "status": "FILLED",
+            "orderLegCollection": ["bad", 99],
+        }
+        result = orders._prune_order(order)
+        assert isinstance(result, dict)
+        assert "legs" not in result.keys()
+
+    def test_non_dict_order_passes_through(self):
+        """Non-dict input to _prune_order must be returned unchanged."""
+        assert orders._prune_order("raw") == "raw"
+        assert orders._prune_order(None) is None

--- a/tests/test_quotes.py
+++ b/tests/test_quotes.py
@@ -43,3 +43,114 @@ def test_get_quotes_parses_symbols_and_fields(monkeypatch, fake_call_factory):
         client.Quote.Fields.FUNDAMENTAL,
     ]
     assert kwargs["indicative"] is False
+
+
+# ---------------------------------------------------------------------------
+# _prune_quote / _prune_quotes helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_RAW_QUOTE_ENTRY = {
+    "assetMainType": "EQUITY",
+    "symbol": "AAPL",
+    "quoteType": "NBBO",
+    "quote": {
+        "lastPrice": 195.50,
+        "bidPrice": 195.45,
+        "askPrice": 195.55,
+        "mark": 195.50,
+        "netChange": 1.23,
+        "netPercentChange": 0.63,
+        "highPrice": 196.00,
+        "lowPrice": 194.50,
+        "totalVolume": 54321000,
+        "bidSize": 100,
+        "askSize": 200,
+        "openPrice": 194.80,
+    },
+    "reference": {"cusip": "037833100", "exchange": "Q"},
+    "fundamental": {"peRatio": 30.5, "eps": 6.43},
+}
+
+_SAMPLE_PAYLOAD = {"AAPL": _SAMPLE_RAW_QUOTE_ENTRY}
+
+
+def test_prune_quotes_compact_default(monkeypatch, fake_call_factory):
+    _, fake_call = fake_call_factory(return_value=_SAMPLE_PAYLOAD)
+    monkeypatch.setattr(quotes, "call", fake_call)
+
+    client = DummyQuotesClient()
+    ctx = make_ctx(client)
+    result = run(quotes.get_quotes(ctx, "AAPL"))
+
+    assert isinstance(result, dict)
+    entry = result["AAPL"]
+    assert entry["symbol"] == "AAPL"
+    # Compact fields present
+    assert entry["lastPrice"] == 195.50
+    assert entry["bidPrice"] == 195.45
+    assert entry["askPrice"] == 195.55
+    assert entry["mark"] == 195.50
+    assert entry["netChange"] == 1.23
+    assert entry["netPercentChange"] == 0.63
+    assert entry["highPrice"] == 196.00
+    assert entry["lowPrice"] == 194.50
+    assert entry["totalVolume"] == 54321000
+    # Extra quote fields stripped
+    assert "bidSize" not in entry
+    assert "askSize" not in entry
+    assert "openPrice" not in entry
+    # Top-level blocks stripped
+    assert "fundamental" not in entry
+    assert "reference" not in entry
+    assert "quoteType" not in entry
+
+
+def test_prune_quotes_verbose_returns_raw(monkeypatch, fake_call_factory):
+    _, fake_call = fake_call_factory(return_value=_SAMPLE_PAYLOAD)
+    monkeypatch.setattr(quotes, "call", fake_call)
+
+    client = DummyQuotesClient()
+    ctx = make_ctx(client)
+    result = run(quotes.get_quotes(ctx, "AAPL", verbose=True))
+
+    assert result is _SAMPLE_PAYLOAD
+    assert result["AAPL"]["fundamental"] == {"peRatio": 30.5, "eps": 6.43}
+
+
+def test_prune_quotes_non_dict_passthrough():
+    assert quotes._prune_quotes("not a dict") == "not a dict"
+    assert quotes._prune_quotes(None) is None
+    assert quotes._prune_quotes([1, 2, 3]) == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Fix #1: _COMPACT_QUOTE_FIELDS is a tuple — stable iteration order
+# ---------------------------------------------------------------------------
+
+
+def test_compact_quote_fields_is_tuple():
+    assert isinstance(quotes._COMPACT_QUOTE_FIELDS, tuple)
+
+
+def test_compact_quote_fields_iteration_order_is_stable():
+    """Iterating the tuple twice must yield the same order."""
+    first = list(quotes._COMPACT_QUOTE_FIELDS)
+    second = list(quotes._COMPACT_QUOTE_FIELDS)
+    assert first == second
+
+
+def test_prune_quote_output_key_order_is_stable():
+    """Keys emitted by _prune_quote must follow _COMPACT_QUOTE_FIELDS order."""
+    entry = {
+        "symbol": "AAPL",
+        "quote": {k: i for i, k in enumerate(quotes._COMPACT_QUOTE_FIELDS)},
+    }
+    result = quotes._prune_quote("AAPL", entry)
+    pruned_keys = [k for k in result if k != "symbol"]
+    assert pruned_keys == list(quotes._COMPACT_QUOTE_FIELDS)
+
+
+def test_compact_quote_fields_membership_check_works():
+    """'in' membership check must still work on a tuple."""
+    assert "lastPrice" in quotes._COMPACT_QUOTE_FIELDS
+    assert "bidSize" not in quotes._COMPACT_QUOTE_FIELDS


### PR DESCRIPTION
## Summary

- Add compact-by-default responses (matching the `get_option_chain`/`get_advanced_option_chain` pattern from #109) to `get_quotes`, `get_account`/`get_accounts`/`get_account_with_positions`/`get_accounts_with_positions`, and `get_order`/`get_orders`.
- Each tool now returns a small, documented field set by default and accepts a `verbose=False` parameter to opt back into the exact original raw payload.
- Quotes: symbol, last/bid/ask/mark, net change, day high/low, volume.
- Accounts: account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue (drops `initialBalances`/`projectedBalances`); positions reduced to symbol, net quantity (positive=long, negative=short), marketValue, averagePrice, unrealizedPL.
- Orders: core status/price/quantity fields, a leg summary (symbol/instruction/quantity), and recursively-pruned `childOrderStrategies` (drops routing metadata and execution activity noise while preserving the TRIGGER/OCO hierarchy needed to check fill status).

## Why

Fixes #113. These tools return large, deeply-nested payloads by default even when the caller only needs a handful of fields — every field costs real tokens in agent-driven usage. Fetching account equity for position sizing was pulling full balance/position data for every linked account, and checking order fill status after a bracket order pulled the entire nested order tree with routing/tag metadata that wasn't needed. `get_option_chain` already solved this with a compact-by-default / `verbose` opt-in pattern; this extends the same pattern to the remaining read tools.

## Testing

- Added tests covering compact-default pruning and `verbose=True` byte-for-byte passthrough for all 7 affected tools, plus edge cases: nested `childOrderStrategies` recursion, long+short position quantity netting, multi-status order merge/dedup still working after the `get_orders` control-flow refactor, and defensive non-dict passthrough.
- `uv run ruff check`, `uv run pyright`, and `uv run pytest` all pass (332 tests).
