### PR TITLE
fix(orders): accept GTC/IOC/FOK duration aliases

### DIFF
--- a/src/schwab_mcp/resources.py
+++ b/src/schwab_mcp/resources.py
@@ -189,10 +189,29 @@ TRADING_SESSIONS: dict[str, Any] = {
             "description": "Order remains active until filled or canceled",
             "max_days": 180,
             "default": False,
+            "alias": "GTC",
         },
         "FILL_OR_KILL": {
             "description": "Must fill immediately and completely, or cancel",
             "valid_for": ["LIMIT", "STOP_LIMIT"],
+            "default": False,
+            "alias": "FOK",
+        },
+        "IMMEDIATE_OR_CANCEL": {
+            "description": "Fill immediately (fully or partially); cancel any unfilled remainder",
+            "default": False,
+            "alias": "IOC",
+        },
+        "END_OF_WEEK": {
+            "description": "Order remains active until the end of the current trading week",
+            "default": False,
+        },
+        "END_OF_MONTH": {
+            "description": "Order remains active until the end of the current calendar month",
+            "default": False,
+        },
+        "NEXT_END_OF_MONTH": {
+            "description": "Order remains active until the end of the following calendar month",
             "default": False,
         },
     },
@@ -200,6 +219,8 @@ TRADING_SESSIONS: dict[str, Any] = {
         "Extended hours have wider spreads and lower liquidity",
         "Not all securities trade in extended hours",
         "FILL_OR_KILL only works with LIMIT and STOP_LIMIT orders",
+        "Common shorthand is accepted: GTC, IOC, and FOK are normalized to "
+        "their full duration names before submission",
     ],
 }
 

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -10,6 +10,7 @@ from schwab.utils import (
     UnsuccessfulOrderException,
     Utils as SchwabUtils,
 )
+from schwab.orders.common import Duration
 from schwab.orders.common import first_triggers_second as trigger_builder
 from schwab.orders.common import one_cancels_other as oco_builder
 from schwab.orders.options import OptionSymbol
@@ -104,15 +105,56 @@ def _prune_orders(payload: JSONType) -> JSONType:
     )
 
 
+# Common shorthand aliases for schwab-py's Duration enum values. GTC is the
+# most frequently used trading abbreviation and is not recognized by
+# schwab-py itself; IOC/FOK are included as the same kind of well-known
+# shorthand. There is no unambiguous shorthand for END_OF_WEEK/END_OF_MONTH/
+# NEXT_END_OF_MONTH, so those are only accepted by their exact enum names.
+_DURATION_ALIASES: dict[str, str] = {
+    "GTC": "GOOD_TILL_CANCEL",
+    "IOC": "IMMEDIATE_OR_CANCEL",
+    "FOK": "FILL_OR_KILL",
+}
+
+# Derived from schwab-py's real Duration enum (rather than hardcoded) so this
+# automatically tracks any values schwab-py adds in future releases.
+_VALID_DURATIONS: frozenset[str] = frozenset(d.name for d in Duration)
+
+
+def _normalize_duration(duration: str | Duration) -> str:
+    """Resolve a duration string/alias to a canonical schwab-py Duration name.
+
+    Accepts common shorthand (e.g. ``GTC``) in addition to the exact
+    schwab-py enum names, case-insensitively. Also accepts a ``Duration``
+    enum instance directly. Raises ``ValueError`` locally (before any Schwab
+    API call) if the value isn't recognized.
+    """
+    if isinstance(duration, Duration):
+        return duration.name
+    if not isinstance(duration, str):
+        raise ValueError(
+            f"Invalid duration: {duration!r}. Must be a string or Duration enum value."
+        )
+    candidate = duration.strip().upper()
+    candidate = _DURATION_ALIASES.get(candidate, candidate)
+
+    if candidate not in _VALID_DURATIONS:
+        raise ValueError(
+            f"Invalid duration: {duration!r}. Must be one of: "
+            f"{', '.join(sorted(_VALID_DURATIONS))} "
+            f"(aliases accepted: {', '.join(sorted(_DURATION_ALIASES))})"
+        )
+
+    return candidate
+
+
 # Internal helper function to apply session and duration settings
 def _apply_order_settings(order_spec, session: str | None, duration: str | None):
     """Internal helper to apply session and duration to an order spec builder."""
     if session:
         order_spec = order_spec.set_session(session)
-    # Apply duration only if it's provided and applicable (not None)
-    # Let schwab-py or the API handle invalid duration types for specific orders
-    if duration:
-        order_spec = order_spec.set_duration(duration)
+    if duration is not None:
+        order_spec = order_spec.set_duration(_normalize_duration(duration))
     return order_spec
 
 
@@ -400,7 +442,7 @@ async def place_equity_order(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default), GOOD_TILL_CANCEL, FILL_OR_KILL (Limit/StopLimit only)",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), IMMEDIATE_OR_CANCEL (alias: IOC), FILL_OR_KILL (alias: FOK; Limit/StopLimit only). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> JSONType:
     """
@@ -449,7 +491,7 @@ async def place_option_order(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default), GOOD_TILL_CANCEL, FILL_OR_KILL (Limit only)",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), IMMEDIATE_OR_CANCEL (alias: IOC), FILL_OR_KILL (alias: FOK; Limit only). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> JSONType:
     """
@@ -500,7 +542,7 @@ async def place_equity_trailing_stop_order(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default) or GOOD_TILL_CANCEL",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), or IMMEDIATE_OR_CANCEL (alias: IOC). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> JSONType:
     """
@@ -545,7 +587,7 @@ async def build_equity_order_spec(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default), GOOD_TILL_CANCEL, FILL_OR_KILL (Limit/StopLimit only)",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), IMMEDIATE_OR_CANCEL (alias: IOC), FILL_OR_KILL (alias: FOK; Limit/StopLimit only). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> dict[str, Any]:
     """
@@ -583,7 +625,7 @@ async def build_equity_trailing_stop_order_spec(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default) or GOOD_TILL_CANCEL",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), or IMMEDIATE_OR_CANCEL (alias: IOC). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> dict[str, Any]:
     """
@@ -618,7 +660,7 @@ async def build_option_order_spec(
     ] = "NORMAL",
     duration: Annotated[
         str | None,
-        "Order duration: DAY (default), GOOD_TILL_CANCEL, FILL_OR_KILL (Limit only)",
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), IMMEDIATE_OR_CANCEL (alias: IOC), FILL_OR_KILL (alias: FOK; Limit only). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> dict[str, Any]:
     """
@@ -777,7 +819,8 @@ async def place_bracket_order(
         str | None, "Trading session: NORMAL (default), AM, PM, or SEAMLESS"
     ] = "NORMAL",
     duration: Annotated[
-        str | None, "Order duration: DAY (default), GOOD_TILL_CANCEL"
+        str | None,
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), or IMMEDIATE_OR_CANCEL (alias: IOC). Invalid values raise ValueError locally.",
     ] = "DAY",
 ) -> JSONType:
     """
@@ -890,7 +933,8 @@ async def place_option_combo_order(
         str | None, "Trading session: NORMAL (default), AM, PM, or SEAMLESS"
     ] = "NORMAL",
     duration: Annotated[
-        str | None, "Order duration: DAY (default) or GOOD_TILL_CANCEL"
+        str | None,
+        "Order duration: DAY (default), GOOD_TILL_CANCEL (alias: GTC), or IMMEDIATE_OR_CANCEL (alias: IOC). Invalid values raise ValueError locally.",
     ] = "DAY",
     complex_order_strategy_type: Annotated[
         str | None,

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -20,6 +20,61 @@ class DummyOrdersClient:
         return None
 
 
+class TestNormalizeDuration:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("DAY", "DAY"),
+            ("day", "DAY"),
+            ("GOOD_TILL_CANCEL", "GOOD_TILL_CANCEL"),
+            ("GTC", "GOOD_TILL_CANCEL"),
+            ("gtc", "GOOD_TILL_CANCEL"),
+            (" GTC ", "GOOD_TILL_CANCEL"),
+            ("FILL_OR_KILL", "FILL_OR_KILL"),
+            ("FOK", "FILL_OR_KILL"),
+            ("IOC", "IMMEDIATE_OR_CANCEL"),
+            ("IMMEDIATE_OR_CANCEL", "IMMEDIATE_OR_CANCEL"),
+            ("END_OF_WEEK", "END_OF_WEEK"),
+        ],
+    )
+    def test_resolves_valid_values_and_aliases(self, raw, expected):
+        assert orders._normalize_duration(raw) == expected
+
+    def test_rejects_unknown_value_with_helpful_message(self):
+        with pytest.raises(ValueError, match="Invalid duration: 'BOGUS'"):
+            orders._normalize_duration("BOGUS")
+
+    def test_rejects_non_string_with_helpful_message(self):
+        with pytest.raises(ValueError, match="Invalid duration"):
+            orders._normalize_duration(123)  # type: ignore[arg-type]
+
+    def test_accepts_duration_enum_instance(self):
+        assert (
+            orders._normalize_duration(orders.Duration.GOOD_TILL_CANCEL)
+            == "GOOD_TILL_CANCEL"
+        )
+
+    def test_empty_string_raises_before_api_call(
+        self, monkeypatch, place_order_client_factory
+    ):
+        place_order_client = place_order_client_factory(account_hash="acc", order_id=1)
+        ctx = make_ctx(place_order_client)
+        with pytest.raises(ValueError, match="Invalid duration"):
+            run(
+                orders.place_equity_order(
+                    ctx,
+                    "acc",
+                    "AAPL",
+                    50,
+                    "buy",
+                    "limit",
+                    price=175.00,
+                    duration="",
+                )
+            )
+        assert place_order_client.captured is None
+
+
 class TestGetOrders:
     def test_maps_single_status_and_dates(self, monkeypatch):
         captured: dict[str, Any] = {}
@@ -437,6 +492,47 @@ class TestPlaceEquityOrder:
         order_spec = place_order_client.captured["kwargs"]["order_spec"]
         assert order_spec["session"] == "AM"
         assert order_spec["duration"] == "GOOD_TILL_CANCEL"
+
+    @pytest.mark.parametrize("alias", ["GTC", "gtc", " GTC "])
+    def test_gtc_alias_matches_good_till_cancel(
+        self, place_order_client, account_hash, alias
+    ):
+        ctx = make_ctx(place_order_client)
+        run(
+            orders.place_equity_order(
+                ctx,
+                account_hash,
+                "AAPL",
+                50,
+                "buy",
+                "limit",
+                price=175.00,
+                duration=alias,
+            )
+        )
+
+        order_spec = place_order_client.captured["kwargs"]["order_spec"]
+        assert order_spec["duration"] == "GOOD_TILL_CANCEL"
+
+    def test_invalid_duration_raises_before_api_call(
+        self, place_order_client, account_hash
+    ):
+        ctx = make_ctx(place_order_client)
+        with pytest.raises(ValueError, match="Invalid duration"):
+            run(
+                orders.place_equity_order(
+                    ctx,
+                    account_hash,
+                    "AAPL",
+                    50,
+                    "buy",
+                    "limit",
+                    price=175.00,
+                    duration="BOGUS",
+                )
+            )
+
+        assert place_order_client.captured is None
 
 
 class TestPlaceOptionOrder:


### PR DESCRIPTION
## Summary

- Order tools (`place_equity_order`, `place_option_order`, `place_equity_trailing_stop_order`, `place_bracket_order`, `place_option_combo_order`, and the `build_*_order_spec` helpers) passed `duration` straight through to schwab-py's `set_duration()` with no local validation, since every order builder is constructed with `enforce_enums=False`. A common shorthand like `duration="GTC"` silently passed through the builder and only failed later at the live Schwab API call with an unhelpful `Invalid value 'GTC'` error.
- Add `_normalize_duration()` at the shared `_apply_order_settings` chokepoint used by every order tool: it normalizes common aliases (`GTC` -> `GOOD_TILL_CANCEL`, `IOC` -> `IMMEDIATE_OR_CANCEL`, `FOK` -> `FILL_OR_KILL`, case/whitespace-insensitive), then validates the result against schwab-py's real `Duration` enum (derived dynamically, not hardcoded) and raises `ValueError` locally with the accepted values before any order is built or submitted.
- Updated the `duration` `Annotated` hints across all affected tools to mention the accepted aliases, and expanded the `trading-sessions` reference resource to document the full duration set (previously only listed 3 of the 7 real schwab-py values) plus the shorthand aliases.

## Why

Hit this live while placing a stop-loss order after a bracket-order OCO leg was rejected: `duration="GTC"` failed against the real API, requiring a second round trip with the exact enum string to succeed. `GTC` is the far more common trading abbreviation than `GOOD_TILL_CANCEL`, so it's worth accepting directly rather than relying on callers remembering the exact schwab-py spelling. Fixing it once in `_apply_order_settings` covers every order-placing tool without duplicating validation per tool.

Closes #112

## Testing

- Added `TestNormalizeDuration`: parametrized coverage of valid values, aliases (including lowercase and whitespace-padded `GTC`), and an invalid-value `ValueError` with a helpful message.
- Added `test_gtc_alias_matches_good_till_cancel` and `test_invalid_duration_raises_before_api_call` to `TestPlaceEquityOrder`, confirming the alias produces the same order spec as `GOOD_TILL_CANCEL` and that an invalid duration raises before any client call is made.
- `uv run ruff check .`, `uv run pyright`, and `uv run pytest` all pass (332 tests).
