### PR TITLE
fix(tools): stop indicator tools defaulting points to length

### DIFF
--- a/src/schwab_mcp/tools/technical/base.py
+++ b/src/schwab_mcp/tools/technical/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime as _dt
 from dataclasses import dataclass
 from collections.abc import Callable
-from typing import Annotated, Any, Iterable, Mapping, TypeAlias, cast
+from typing import Annotated, Any, Final, Iterable, Mapping, TypeAlias, cast
 
 import pandas as pd
 
@@ -27,6 +27,7 @@ __all__ = [
     "StartTime",
     "EndTime",
     "Points",
+    "DEFAULT_POINTS",
 ]
 
 Symbol: TypeAlias = Annotated[str, "Symbol of the security"]
@@ -49,11 +50,16 @@ EndTime: TypeAlias = Annotated[
     "Optional ISO-8601 timestamp for the final candle (defaults to now in UTC).",
 ]
 
+DEFAULT_POINTS: Final[int] = 3
+
 Points: TypeAlias = Annotated[
     int | None,
     (
-        "Limit the number of indicator values returned. Defaults to the primary "
-        "length parameter. Use a larger number to inspect more history."
+        "Number of rows to return (not the calculation window). "
+        f"When omitted, defaults to up to {DEFAULT_POINTS} most-recent rows "
+        "(fewer if less data is available). "
+        "Pass points=1 for a cheap latest-value read. "
+        "A larger length does NOT by itself increase the number of returned rows."
     ),
 ]
 
@@ -180,7 +186,6 @@ async def compute_series_indicator(
     end: str | None,
     bars: int,
     points: int | None,
-    default_points: int,
     value_key: str,
     required_columns: tuple[str, ...] = ("close",),
     extra_metadata: dict[str, Any] | None = None,
@@ -211,7 +216,7 @@ async def compute_series_indicator(
 
     values = series_to_json(
         result,
-        limit=points if points is not None else default_points,
+        limit=points if points is not None else DEFAULT_POINTS,
         value_key=value_key,
     )
 
@@ -239,7 +244,6 @@ async def compute_frame_indicator(
     end: str | None,
     bars: int,
     points: int | None,
-    default_points: int,
     required_columns: tuple[str, ...] = ("close",),
     extra_metadata: dict[str, Any] | None = None,
 ) -> JSONType:
@@ -269,7 +273,7 @@ async def compute_frame_indicator(
 
     values = frame_to_json(
         result,
-        limit=points if points is not None else default_points,
+        limit=points if points is not None else DEFAULT_POINTS,
     )
 
     response: dict[str, Any] = {

--- a/src/schwab_mcp/tools/technical/momentum.py
+++ b/src/schwab_mcp/tools/technical/momentum.py
@@ -46,7 +46,6 @@ async def rsi(
         end=end,
         bars=compute_window(length, multiplier=3, min_padding=20),
         points=points,
-        default_points=length,
         value_key=f"rsi_{length}",
         extra_metadata={"length": length},
     )
@@ -88,7 +87,6 @@ async def stoch(
         end=end,
         bars=compute_window(longest, multiplier=3, min_padding=5),
         points=points,
-        default_points=k_length,
         required_columns=("high", "low", "close"),
         extra_metadata={
             "k_length": k_length,

--- a/src/schwab_mcp/tools/technical/moving_average.py
+++ b/src/schwab_mcp/tools/technical/moving_average.py
@@ -45,7 +45,6 @@ async def sma(
         end=end,
         bars=compute_window(length, multiplier=2, min_padding=10),
         points=points,
-        default_points=length,
         value_key=f"sma_{length}",
         extra_metadata={"length": length},
     )
@@ -74,7 +73,6 @@ async def ema(
         end=end,
         bars=compute_window(length, multiplier=2, min_padding=10),
         points=points,
-        default_points=length,
         value_key=f"ema_{length}",
         extra_metadata={"length": length},
     )

--- a/src/schwab_mcp/tools/technical/overlays.py
+++ b/src/schwab_mcp/tools/technical/overlays.py
@@ -10,6 +10,7 @@ from schwab_mcp.tools._registration import register_tool
 from schwab_mcp.tools.utils import JSONType
 
 from .base import (
+    DEFAULT_POINTS,
     EndTime,
     Interval,
     Points,
@@ -149,10 +150,9 @@ async def vwap(
     if vwap_series.empty:
         raise ValueError("Not enough price history to compute VWAP.")
 
-    default_points = length if length is not None else 30
     values = series_to_json(
         vwap_series,
-        limit=points if points is not None else default_points,
+        limit=points if points is not None else DEFAULT_POINTS,
         value_key="vwap",
     )
 
@@ -198,7 +198,6 @@ async def pivot_points(
         end=end,
         bars=bars or 50,
         points=points,
-        default_points=lookback if lookback is not None else 10,
         required_columns=("high", "low", "close"),
         extra_metadata={"method": method, "lookback": lookback},
     )
@@ -236,7 +235,6 @@ async def bollinger_bands(
         end=end,
         bars=compute_window(length, multiplier=3, min_padding=20),
         points=points,
-        default_points=length,
         extra_metadata={"length": length, "std_dev": std_dev, "ma_mode": ma_mode},
     )
 

--- a/src/schwab_mcp/tools/technical/trend.py
+++ b/src/schwab_mcp/tools/technical/trend.py
@@ -55,7 +55,6 @@ async def macd(
         end=end,
         bars=max(slow_length * 5, slow_length + signal_length + 20),
         points=points,
-        default_points=slow_length,
         extra_metadata={
             "fast_length": fast_length,
             "slow_length": slow_length,
@@ -92,7 +91,6 @@ async def atr(
         end=end,
         bars=compute_window(length, multiplier=4, min_padding=20),
         points=points,
-        default_points=length,
         value_key=f"atr_{length}",
         required_columns=("high", "low", "close"),
         extra_metadata={"length": length},
@@ -127,7 +125,6 @@ async def adx(
         end=end,
         bars=compute_window(length, multiplier=4, min_padding=20),
         points=points,
-        default_points=length,
         required_columns=("high", "low", "close"),
         extra_metadata={"length": length},
     )

--- a/tests/test_technical_tools.py
+++ b/tests/test_technical_tools.py
@@ -109,7 +109,7 @@ def test_sma_returns_expected_values(monkeypatch, dummy_ctx, price_data):
         assert row["sma_3"] == pytest.approx(float(expected_value))
 
 
-def test_ema_defaults_to_length_points(monkeypatch, dummy_ctx, price_data):
+def test_ema_defaults_to_default_points(monkeypatch, dummy_ctx, price_data):
     frame, metadata = price_data
 
     async def fake_fetch(ctx, symbol, **kwargs):
@@ -126,12 +126,12 @@ def test_ema_defaults_to_length_points(monkeypatch, dummy_ctx, price_data):
         SimpleNamespace(ema=fake_ema),
     )
 
-    result = run_tool(moving_average.ema(dummy_ctx, "HOOD", length=4))
+    result = run_tool(moving_average.ema(dummy_ctx, "HOOD", length=5))
 
     values = result["values"]
-    assert len(values) == 4
-    last_value = frame["close"].ewm(span=4, adjust=False).mean().iloc[-1]
-    assert values[-1]["ema_4"] == pytest.approx(float(last_value))
+    assert len(values) == base.DEFAULT_POINTS
+    last_value = frame["close"].ewm(span=5, adjust=False).mean().iloc[-1]
+    assert values[-1]["ema_5"] == pytest.approx(float(last_value))
 
 
 def test_rsi_returns_expected_values(monkeypatch, dummy_ctx, price_data):
@@ -716,3 +716,95 @@ def test_expected_move_honors_custom_multiplier(monkeypatch, dummy_ctx):
 
     assert result["adjusted_move"] == pytest.approx(4.0 * 1.2)
     assert result["boundaries"]["upper_1x"] == pytest.approx(100.0 + 4.8)
+
+
+def test_sma_defaults_to_default_points_not_length(monkeypatch, dummy_ctx, price_data):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    def fake_sma(series, *, length):
+        return series.rolling(length, min_periods=1).mean()
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        moving_average,
+        "pandas_ta",
+        SimpleNamespace(sma=fake_sma),
+    )
+
+    result = run_tool(moving_average.sma(dummy_ctx, "HOOD", length=5))
+
+    values = result["values"]
+    assert len(values) == base.DEFAULT_POINTS
+    last_value = frame["close"].rolling(5, min_periods=1).mean().iloc[-1]
+    assert values[-1]["sma_5"] == pytest.approx(float(last_value))
+
+
+def test_atr_defaults_to_default_points_not_length(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    def fake_atr(high, low, close, *, length):
+        return pd.Series([1.0 + idx for idx in range(len(close))], index=close.index)
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        trend,
+        "pandas_ta",
+        SimpleNamespace(
+            atr=fake_atr,
+            adx=lambda *args, **kwargs: None,
+            macd=lambda *args, **kwargs: None,
+        ),
+    )
+
+    result = run_tool(trend.atr(dummy_ctx, "HOOD", length=5))
+
+    values = result["values"]
+    assert len(values) == base.DEFAULT_POINTS
+    assert values[-1]["atr_5"] == pytest.approx(1.0 + len(frame) - 1)
+
+
+def test_vwap_defaults_to_default_points_not_length(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    def fake_vwap(high, low, close, volume, *, length=None):
+        return pd.Series([100.0 + idx for idx in range(len(close))], index=close.index)
+
+    monkeypatch.setattr(overlays, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        overlays,
+        "pandas_ta",
+        SimpleNamespace(vwap=fake_vwap, pivot_points=None, bbands=None),
+    )
+
+    result = run_tool(overlays.vwap(dummy_ctx, "HOOD", length=5))
+
+    values = result["values"]
+    assert len(values) == base.DEFAULT_POINTS
+    assert values[-1]["vwap"] == pytest.approx(100.0 + len(frame) - 1)
+
+
+def test_pivot_points_defaults_to_default_points_not_lookback(
+    monkeypatch, dummy_ctx, ohlcv_data
+):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(
+        overlays.pivot_points(dummy_ctx, "HOOD", method="standard", lookback=1)
+    )
+
+    values = result["values"]
+    assert len(values) == base.DEFAULT_POINTS


### PR DESCRIPTION
## What

Indicator tools (`sma`, `ema`, `rsi`, `stoch`, `macd`, `atr`, `adx`, `bollinger_bands`, `vwap`, `pivot_points`) defaulted the `points` (rows returned) parameter to the tool's own calculation window (`length`/`k_length`/`slow_length`/`lookback`) whenever `points` was omitted. A simple "what's the current SMA(50)?" call dumped up to 50 timestamped rows instead of the one number being asked for.

## Why

Hit this during a live trading session: pulling SMA(50), SMA(200), EMA(21), and ATR(14) for one symbol as single current-level readings for stop placement returned 19, 76, 9, and 14 rows respectively, none needed beyond the latest value. The `points` docstring already framed the parameter as being about limiting output, but nothing tied the default to a small number — it was tied to the calculation window instead, so a bigger `length` silently meant a bigger default response for no reason.

## How

- Added a single shared `DEFAULT_POINTS = 3` constant in `technical/base.py` and moved it inside `compute_series_indicator`/`compute_frame_indicator` directly, removing the `default_points` parameter those helpers used to take. Every helper-based indicator now gets the same small default with no per-call wiring, so the bug can't be reintroduced by a future indicator accidentally passing `length` again.
- Dropped the now-dead `default_points=length` (and `k_length`/`slow_length` equivalents) argument from `sma`, `ema`, `rsi`, `stoch`, `macd`, `atr`, `adx`, `bollinger_bands`.
- Fixed the two indicators that build their `values` list by hand instead of going through the shared helpers (`vwap`, `pivot_points`) — both had the same length/lookback-scaled default inline; they now use the same `DEFAULT_POINTS` constant.
- Reworded the `Points` docstring to say what it actually does now: it only limits rows returned, defaults to 3 most-recent rows, `points=1` is the cheap latest-value read, and a larger `length` no longer inflates the response.
- `length`/`lookback`/the fetch window (`bars`/`compute_window`) are untouched — the calculation still gets its full warm-up history, only the number of rows serialized back to the caller changes.
- `historical_volatility` was in the issue's tool list but doesn't take a `points` parameter at all (it returns a single summary dict, not a row series), so it isn't touched here.

## Testing

- Rewrote `test_ema_defaults_to_length_points` (renamed `test_ema_defaults_to_default_points`) and added `test_sma_defaults_to_default_points_not_length`, `test_atr_defaults_to_default_points_not_length`, `test_vwap_defaults_to_default_points_not_length`, and `test_pivot_points_defaults_to_default_points_not_lookback`. Each picks a `length`/`lookback` that would have produced a different row count under the old code, so they'd have failed pre-fix.
- `uv run ruff check .` — clean
- `uv run pyright` — clean
- `uv run pytest` — 320 passed

Fixes #114
