### PR TITLE
refactor(tools): extract run_approval helper from approval wrapper

### DIFF
--- a/src/schwab_mcp/tools/_registration.py
+++ b/src/schwab_mcp/tools/_registration.py
@@ -120,6 +120,32 @@ def _format_argument(value: Any) -> str:
     return text
 
 
+async def run_approval(
+    context: SchwabContext, request: ApprovalRequest
+) -> ApprovalDecision:
+    """Run an approval request through progress reporting and the configured
+    :class:`ApprovalManager`, returning the resulting decision.
+
+    Shared by the automatic write-tool approval wrapping below and by tools
+    that need to build their own :class:`ApprovalRequest` (e.g. to surface
+    resolved state rather than raw call arguments to the reviewer).
+    """
+    if _has_progress_token(context):
+        await context.report_progress(0, 1, _APPROVAL_WAIT_MESSAGE)
+    keepalive_task = _start_approval_keepalive(context)
+
+    try:
+        decision = await context.approvals.require(request)
+    finally:
+        if keepalive_task is not None:
+            keepalive_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await keepalive_task
+
+    await _report_approval_completion(context, decision)
+    return decision
+
+
 def _wrap_with_approval(func: ToolFn) -> ToolFn:
     signature, ctx_params = _resolve_context_parameters(func)
     if not ctx_params:
@@ -170,19 +196,7 @@ def _wrap_with_approval(func: ToolFn) -> ToolFn:
             arguments=arguments,
         )
 
-        if _has_progress_token(context):
-            await context.report_progress(0, 1, _APPROVAL_WAIT_MESSAGE)
-        keepalive_task = _start_approval_keepalive(context)
-
-        try:
-            decision = await context.approvals.require(request)
-        finally:
-            if keepalive_task is not None:
-                keepalive_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await keepalive_task
-
-        await _report_approval_completion(context, decision)
+        decision = await run_approval(context, request)
         logger.info(
             "Approval decision %s for tool '%s' (approval_id=%s, client_id=%s, request_id=%s)",
             decision.value,
@@ -331,4 +345,4 @@ def register_tool(
     )(func)
 
 
-__all__ = ["register_tool"]
+__all__ = ["register_tool", "run_approval"]


### PR DESCRIPTION
Pulls the progress/keepalive/require/completion-report sequence out of `_wrap_with_approval` into a standalone `run_approval()` function, exported so tools that need to build their own `ApprovalRequest` (rather than relying on automatic argument formatting) can reuse the same flow.

Pure refactor, no behavior change. Split out of #118 so it can be reviewed and merged independently.

## Testing

- `ruff format`, `ruff check`, `pyright`, `pytest` all pass (347 tests, no regressions)