### PR TITLE
refactor(tools): consolidate account tools with include_positions flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The server provides a rich set of tools for LLMs.
 | Tool | Description |
 |------|-------------|
 | `get_accounts` | List linked accounts (pass `include_positions=True` for holdings). |
-| `get_account` | Balances/positions for one account by hash. |
+| `get_account` | Balances for one account by hash (pass `include_positions=True` for holdings). |
 | `get_transactions` | History of trades and transfers. |
 | `get_orders` | Status of open and filled orders. |
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ The server provides a rich set of tools for LLMs.
 ### 💼 Account Info
 | Tool | Description |
 |------|-------------|
-| `get_accounts` | List linked accounts. |
-| `get_account_positions` | Detailed positions and balances. |
+| `get_accounts` | List linked accounts (pass `include_positions=True` for holdings). |
+| `get_account` | Balances/positions for one account by hash. |
 | `get_transactions` | History of trades and transfers. |
 | `get_orders` | Status of open and filled orders. |
 

--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -99,70 +99,46 @@ async def get_account_numbers(
 
 async def get_accounts(
     ctx: SchwabContext,
+    include_positions: Annotated[
+        bool,
+        "Include holdings/positions (symbol, quantity, marketValue, averagePrice, unrealizedPL) for each account.",
+    ] = False,
     verbose: Annotated[
         bool,
         "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
     ] = False,
 ) -> JSONType:
     """
-    Returns balances/info for all linked accounts (funds, cash, margin). Does not return hashes; use get_account_numbers first.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped); pass verbose=True for the full raw payload.
+    Returns balances/info for all linked accounts (funds, cash, margin); pass include_positions=True to also include holdings. Does not return hashes; use get_account_numbers first.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
     """
-    result = await call(ctx.accounts.get_accounts)
-    return result if verbose else _prune_account_response(result)
-
-
-async def get_accounts_with_positions(
-    ctx: SchwabContext,
-    verbose: Annotated[
-        bool,
-        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
-    ] = False,
-) -> JSONType:
-    """
-    Returns balances, info, and positions (holdings, cost, gain/loss) for all linked accounts. Does not return hashes; use get_account_numbers first.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
-    """
-    result = await call(
-        ctx.accounts.get_accounts,
-        fields=[ctx.accounts.Account.Fields.POSITIONS],
-    )
+    kwargs: dict[str, Any] = {}
+    if include_positions:
+        kwargs["fields"] = [ctx.accounts.Account.Fields.POSITIONS]
+    result = await call(ctx.accounts.get_accounts, **kwargs)
     return result if verbose else _prune_account_response(result)
 
 
 async def get_account(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
+    include_positions: Annotated[
+        bool,
+        "Include holdings/positions (symbol, quantity, marketValue, averagePrice, unrealizedPL).",
+    ] = False,
     verbose: Annotated[
         bool,
         "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
     ] = False,
 ) -> JSONType:
     """
-    Returns balance/info for a specific account via account_hash (from get_account_numbers). Includes funds, cash, margin info.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped); pass verbose=True for the full raw payload.
+    Returns balance/info for a specific account via account_hash (from get_account_numbers); pass include_positions=True to also include holdings. Includes funds, cash, margin info.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
     """
-    result = await call(ctx.accounts.get_account, account_hash)
-    return result if verbose else _prune_account_response(result)
-
-
-async def get_account_with_positions(
-    ctx: SchwabContext,
-    account_hash: Annotated[str, "Account hash for the Schwab account"],
-    verbose: Annotated[
-        bool,
-        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
-    ] = False,
-) -> JSONType:
-    """
-    Returns balance, info, and positions for a specific account via account_hash. Includes holdings, quantity, cost basis, unrealized gain/loss.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
-    """
-    result = await call(
-        ctx.accounts.get_account,
-        account_hash,
-        fields=[ctx.accounts.Account.Fields.POSITIONS],
-    )
+    kwargs: dict[str, Any] = {}
+    if include_positions:
+        kwargs["fields"] = [ctx.accounts.Account.Fields.POSITIONS]
+    result = await call(ctx.accounts.get_account, account_hash, **kwargs)
     return result if verbose else _prune_account_response(result)
 
 
@@ -178,9 +154,7 @@ async def get_user_preferences(
 _READ_ONLY_TOOLS = (
     get_account_numbers,
     get_accounts,
-    get_accounts_with_positions,
     get_account,
-    get_account_with_positions,
     get_user_preferences,
 )
 

--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -101,16 +101,16 @@ async def get_accounts(
     ctx: SchwabContext,
     include_positions: Annotated[
         bool,
-        "Include holdings/positions (symbol, quantity, marketValue, averagePrice, unrealizedPL) for each account.",
+        "Request holdings/positions for each account. In compact mode (default) positions are pruned to symbol, quantity, marketValue, averagePrice, unrealizedPL; verbose=True returns the raw, unpruned position fields instead.",
     ] = False,
     verbose: Annotated[
         bool,
-        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+        "Return the full raw payload (all balance types, and full position fields if include_positions=True) instead of the compact default.",
     ] = False,
 ) -> JSONType:
     """
     Returns balances/info for all linked accounts (funds, cash, margin); pass include_positions=True to also include holdings. Does not return hashes; use get_account_numbers first.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
     kwargs: dict[str, Any] = {}
     if include_positions:
@@ -124,16 +124,16 @@ async def get_account(
     account_hash: Annotated[str, "Account hash for the Schwab account"],
     include_positions: Annotated[
         bool,
-        "Include holdings/positions (symbol, quantity, marketValue, averagePrice, unrealizedPL).",
+        "Request holdings/positions. In compact mode (default) positions are pruned to symbol, quantity, marketValue, averagePrice, unrealizedPL; verbose=True returns the raw, unpruned position fields instead.",
     ] = False,
     verbose: Annotated[
         bool,
-        "Return the full raw payload (all balance types, full position fields) instead of the compact default.",
+        "Return the full raw payload (all balance types, and full position fields if include_positions=True) instead of the compact default.",
     ] = False,
 ) -> JSONType:
     """
     Returns balance/info for a specific account via account_hash (from get_account_numbers); pass include_positions=True to also include holdings. Includes funds, cash, margin info.
-    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload.
+    By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
     kwargs: dict[str, Any] = {}
     if include_positions:

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -147,9 +147,21 @@ class TestGetAccounts:
 
         assert result is _RAW_LIST_PAYLOAD
 
+    def test_default_does_not_request_positions_field(
+        self, monkeypatch, fake_call_factory
+    ):
+        captured, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
 
-class TestGetAccountsWithPositions:
-    def test_calls_client_with_positions_field(self, monkeypatch, fake_call_factory):
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        run(account.get_accounts(ctx))
+
+        assert "fields" not in captured["kwargs"]
+
+    def test_include_positions_requests_positions_field(
+        self, monkeypatch, fake_call_factory
+    ):
         captured, fake_call = fake_call_factory(
             return_value=[{"securitiesAccount": {"positions": []}}]
         )
@@ -158,19 +170,21 @@ class TestGetAccountsWithPositions:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_accounts_with_positions(ctx, verbose=True))
+        result = run(account.get_accounts(ctx, include_positions=True, verbose=True))
 
         assert result == [{"securitiesAccount": {"positions": []}}]
         assert captured["func"].__name__ == "get_accounts"
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
 
-    def test_compact_default_prunes_positions(self, monkeypatch, fake_call_factory):
+    def test_include_positions_compact_default_prunes_positions(
+        self, monkeypatch, fake_call_factory
+    ):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_accounts_with_positions(ctx))
+        result = run(account.get_accounts(ctx, include_positions=True))
 
         assert isinstance(result, list)
         sec = result[0]["securitiesAccount"]
@@ -187,13 +201,15 @@ class TestGetAccountsWithPositions:
         assert "settledLongQuantity" not in pos
         assert "maintenanceRequirement" not in pos
 
-    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+    def test_include_positions_verbose_returns_raw_payload(
+        self, monkeypatch, fake_call_factory
+    ):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_accounts_with_positions(ctx, verbose=True))
+        result = run(account.get_accounts(ctx, include_positions=True, verbose=True))
 
         assert result is _RAW_LIST_WITH_POSITIONS
 
@@ -241,9 +257,19 @@ class TestGetAccount:
 
         assert result is _RAW_DICT_PAYLOAD
 
+    def test_default_does_not_request_positions_field(
+        self, monkeypatch, fake_call_factory
+    ):
+        captured, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        monkeypatch.setattr(account, "call", fake_call)
 
-class TestGetAccountWithPositions:
-    def test_calls_client_with_hash_and_positions_field(
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        run(account.get_account(ctx, "hash456"))
+
+        assert "fields" not in captured["kwargs"]
+
+    def test_include_positions_requests_positions_field(
         self, monkeypatch, fake_call_factory
     ):
         captured, fake_call = fake_call_factory(
@@ -254,20 +280,24 @@ class TestGetAccountWithPositions:
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account_with_positions(ctx, "hash789", verbose=True))
+        result = run(
+            account.get_account(ctx, "hash789", include_positions=True, verbose=True)
+        )
 
         assert result == {"securitiesAccount": {"positions": [{"symbol": "SPY"}]}}
         assert captured["func"].__name__ == "get_account"
         assert captured["args"] == ("hash789",)
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
 
-    def test_compact_default_prunes_positions(self, monkeypatch, fake_call_factory):
+    def test_include_positions_compact_default_prunes_positions(
+        self, monkeypatch, fake_call_factory
+    ):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account_with_positions(ctx, "hash789"))
+        result = run(account.get_account(ctx, "hash789", include_positions=True))
 
         assert isinstance(result, dict)
         sec = result["securitiesAccount"]
@@ -283,13 +313,17 @@ class TestGetAccountWithPositions:
         assert pos["unrealizedPL"] == 100.0
         assert "settledLongQuantity" not in pos
 
-    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+    def test_include_positions_verbose_returns_raw_payload(
+        self, monkeypatch, fake_call_factory
+    ):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account_with_positions(ctx, "hash789", verbose=True))
+        result = run(
+            account.get_account(ctx, "hash789", include_positions=True, verbose=True)
+        )
 
         assert result is _RAW_DICT_WITH_POSITIONS
 


### PR DESCRIPTION
## What

`get_accounts`/`get_account` each had a near-duplicate `*_with_positions` sibling that differed only in whether `fields=[Account.Fields.POSITIONS]` was passed to the underlying schwab-py client call. Six near-identical account tools burn tool-schema tokens and create ambiguity about which of two tools an LLM should call for a given request.

Merges each pair into a single tool with an `include_positions: bool = False` parameter (checked before the existing `verbose` flag), dropping `get_accounts_with_positions` and `get_account_with_positions` entirely. `_READ_ONLY_TOOLS` goes from 6 entries down to 4.

- `get_accounts(ctx, include_positions=False, verbose=False)`
- `get_account(ctx, account_hash, include_positions=False, verbose=False)`
- compact pruning (`_prune_account_response`) is unchanged; it already only prunes `positions` when the raw payload has a `positions` key, so this was a pure tool-signature/call-site change
- README account tool table updated to real tool names

## Testing

- `ruff format --check .`, `ruff check .`, `pyright`, `pytest` all pass (376 tests, no regressions)
- `tests/test_account.py` covers the full `include_positions` x `verbose` matrix for both tools, including an explicit assertion that the `fields` kwarg is absent when `include_positions` defaults to `False`
