### PR TITLE
ci: add CodeQL security analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+---
+name: CodeQL
+
+"on":
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "27 3 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - python
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Enables GitHub's CodeQL security scanning for this repo. We don't currently have any static security analysis running in CI, and CodeQL is free for public repos with basically zero setup cost.

Runs on pushes and PRs against `main`, plus a weekly Monday scan to catch anything new from updated CodeQL query packs. Scoped to Python only since that's the only language in the codebase. Job permissions are limited to just what `codeql-action` needs (`security-events: write` to upload results, plus the read-only defaults it recommends).

Findings will show up under the repo's Security tab once this merges.
