### PR TITLE
ci(tools): add vulture dead code check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,5 +36,8 @@ jobs:
       - name: Type check (pyright)
         run: uv run pyright
 
+      - name: Dead code check (vulture)
+        run: uv run vulture
+
       - name: Run tests
         run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pytest>=8.4.2",
     "pytest-cov>=6.0.0",
     "ruff>=0.14.0",
+    "vulture>=2.14",
 ]
 ta = [
     "pandas>=2.2.2",
@@ -73,6 +74,11 @@ venvPath = "."
 venv = ".venv"
 reportMissingImports = false
 typeCheckingMode = "basic"
+
+[tool.vulture]
+paths = ["src"]
+min_confidence = 80
+exclude = ["src/schwab_mcp/tools/_protocols.py"]
 
 [tool.uv.sources]
 schwab-py = { git = "https://github.com/jkoelker/schwab-py.git", rev = "proxy_support" }

--- a/uv.lock
+++ b/uv.lock
@@ -2470,6 +2470,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "vulture" },
 ]
 ta = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2497,6 +2498,7 @@ dev = [
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.14.0" },
+    { name = "vulture", specifier = ">=2.14" },
 ]
 ta = [
     { name = "pandas", specifier = ">=2.2.2" },
@@ -2684,6 +2686,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/f6/cc9aadc0e481344a42095d222bfa764122fb8cfba708d1922917bd8bfb01/uvicorn-0.50.2.tar.gz", hash = "sha256:b92bf03509b82bcb9d49e7335b4fd364518ad021c2dc18b4e6a2fec8c955a0bb", size = 93716, upload-time = "2026-07-06T10:38:31.984Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/f0/7c228ee10c7ab8fd3a21d06579a6f7c6075c6ce72594a20fb5d2f206ff24/uvicorn-0.50.2-py3-none-any.whl", hash = "sha256:4ae72a385630bcc17a0adb8290f26c993865e0b43a2114c2aab96420172c056a", size = 72846, upload-time = "2026-07-06T10:38:30.543Z" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds vulture as a dead-code check in CI, alongside the existing ruff and pyright steps.

Vulture is still the pragmatic choice for this: it's mature, low-dependency, and its usual failure mode (false positives on dynamically-dispatched code) doesn't bite here since tools are registered through explicit tuples (`_READ_ONLY_TOOLS` and friends) rather than decorator magic, so a full run against `src/` comes back clean. Newer Rust-based alternatives exist but are unproven for a codebase this size.

- add `vulture` to the `dev` dependency group
- add `[tool.vulture]` with `min_confidence = 80`, excluding `_protocols.py` since its Protocol methods are structural stubs that are never called directly
- run `uv run vulture` as a CI step between the pyright and pytest steps

Verified locally: `uv run vulture` exits 0 with no findings; ruff format/check, pyright, and the full pytest suite (376 passed) all still pass.
