### PR TITLE
refactor(tools): fold account_numbers/user_preferences into get_accounts

### DIFF
--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -1,13 +1,14 @@
 #
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.tools.utils import JSONType, call
+from schwab_mcp.tools.utils import JSONType, SchwabAPIError, call
 
 _COMPACT_ACCOUNT_FIELDS = frozenset(
     {"type", "accountNumber", "roundTrips", "isDayTrader"}
@@ -22,6 +23,12 @@ _COMPACT_BALANCE_FIELDS = frozenset(
         "liquidationValue",
     }
 )
+
+
+@dataclass(frozen=True, slots=True)
+class AccountIdentity:
+    account_hash: str
+    nickname: str | None
 
 
 def _prune_position(position: dict[str, Any]) -> dict[str, Any]:
@@ -88,13 +95,81 @@ def _prune_account_response(payload: JSONType) -> JSONType:
     return payload
 
 
-async def get_account_numbers(
-    ctx: SchwabContext,
+async def _get_identity_map(ctx: SchwabContext) -> dict[str, AccountIdentity]:
+    """Build accountNumber -> AccountIdentity from account numbers and user preferences.
+
+    Identity enrichment is best-effort metadata: if either upstream endpoint
+    fails, callers still get their primary account/balance data, just without
+    accountHash/nickname enrichment (an empty map is returned).
+    """
+    try:
+        numbers_payload = await call(ctx.accounts.get_account_numbers)
+        prefs_payload = await call(ctx.accounts.get_user_preferences)
+    except SchwabAPIError:
+        return {}
+
+    hash_map = {
+        entry["accountNumber"]: entry["hashValue"]
+        for entry in (numbers_payload if isinstance(numbers_payload, list) else [])
+        if isinstance(entry, dict)
+        and isinstance(entry.get("accountNumber"), str)
+        and isinstance(entry.get("hashValue"), str)
+    }
+
+    accounts = (
+        prefs_payload.get("accounts") if isinstance(prefs_payload, dict) else None
+    )
+    nick_map: dict[str, str | None] = {
+        acct["accountNumber"]: acct.get("nickName")
+        if isinstance(acct.get("nickName"), str)
+        else None
+        for acct in (accounts if isinstance(accounts, list) else [])
+        if isinstance(acct, dict) and isinstance(acct.get("accountNumber"), str)
+    }
+
+    return {
+        acct_num: AccountIdentity(
+            account_hash=hash_val,
+            nickname=nick_map.get(acct_num),
+        )
+        for acct_num, hash_val in hash_map.items()
+    }
+
+
+def _enrich_with_identity(
+    payload: JSONType,
+    identity_map: dict[str, AccountIdentity],
+    *,
+    fallback_hash: str | None = None,
 ) -> JSONType:
+    """Inject accountHash and nickname into each securitiesAccount dict.
+
+    Handles both list-of-accounts and single-account dict shapes.
+    Always sets both keys; falls back to fallback_hash (typically the
+    account_hash the caller already supplied) if no identity-map entry is
+    found, and uses None for nickname in that case.
     """
-    Returns mapping of account IDs to account hashes. Hashes required for account-specific calls. Use first.
-    """
-    return await call(ctx.accounts.get_account_numbers)
+
+    def _enrich_sec(sec: dict[str, Any]) -> None:
+        acct_num = sec.get("accountNumber")
+        identity = identity_map.get(acct_num) if isinstance(acct_num, str) else None
+        sec["accountHash"] = identity.account_hash if identity else fallback_hash
+        sec["nickname"] = identity.nickname if identity else None
+
+    if isinstance(payload, list):
+        for item in payload:
+            if (
+                isinstance(item, dict)
+                and "securitiesAccount" in item
+                and isinstance(item["securitiesAccount"], dict)
+            ):
+                _enrich_sec(item["securitiesAccount"])
+        return payload
+    if isinstance(payload, dict) and "securitiesAccount" in payload:
+        sec = payload["securitiesAccount"]
+        if isinstance(sec, dict):
+            _enrich_sec(sec)
+    return payload
 
 
 async def get_accounts(
@@ -109,19 +184,24 @@ async def get_accounts(
     ] = False,
 ) -> JSONType:
     """
-    Returns balances/info for all linked accounts (funds, cash, margin); pass include_positions=True to also include holdings. Does not return hashes; use get_account_numbers first.
+    Returns balances/info for all linked accounts (funds, cash, margin); pass include_positions=True to also include holdings.
+    Includes each account's accountHash (required for account-specific calls like get_account, orders, transactions) and nickname.
     By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
+    identity_map = await _get_identity_map(ctx)
     kwargs: dict[str, Any] = {}
     if include_positions:
         kwargs["fields"] = [ctx.accounts.Account.Fields.POSITIONS]
     result = await call(ctx.accounts.get_accounts, **kwargs)
-    return result if verbose else _prune_account_response(result)
+    pruned = result if verbose else _prune_account_response(result)
+    return _enrich_with_identity(pruned, identity_map)
 
 
 async def get_account(
     ctx: SchwabContext,
-    account_hash: Annotated[str, "Account hash for the Schwab account"],
+    account_hash: Annotated[
+        str, "Account hash for the Schwab account (from get_accounts)"
+    ],
     include_positions: Annotated[
         bool,
         "Request holdings/positions. In compact mode (default) positions are pruned to symbol, quantity, marketValue, averagePrice, unrealizedPL; verbose=True returns the raw, unpruned position fields instead.",
@@ -132,30 +212,22 @@ async def get_account(
     ] = False,
 ) -> JSONType:
     """
-    Returns balance/info for a specific account via account_hash (from get_account_numbers); pass include_positions=True to also include holdings. Includes funds, cash, margin info.
+    Returns balance/info for a specific account via account_hash (from get_accounts); pass include_positions=True to also include holdings. Includes funds, cash, margin info.
+    Includes the account's accountHash and nickname for self-describing output.
     By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
+    identity_map = await _get_identity_map(ctx)
     kwargs: dict[str, Any] = {}
     if include_positions:
         kwargs["fields"] = [ctx.accounts.Account.Fields.POSITIONS]
     result = await call(ctx.accounts.get_account, account_hash, **kwargs)
-    return result if verbose else _prune_account_response(result)
-
-
-async def get_user_preferences(
-    ctx: SchwabContext,
-) -> JSONType:
-    """
-    Returns user preferences (nicknames, display settings, notifications) for all linked accounts.
-    """
-    return await call(ctx.accounts.get_user_preferences)
+    pruned = result if verbose else _prune_account_response(result)
+    return _enrich_with_identity(pruned, identity_map, fallback_hash=account_hash)
 
 
 _READ_ONLY_TOOLS = (
-    get_account_numbers,
     get_accounts,
     get_account,
-    get_user_preferences,
 )
 
 

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -338,7 +338,7 @@ async def get_order(
 async def get_orders(
     ctx: SchwabContext,
     account_hash: Annotated[
-        str, "Account hash for the Schwab account (from get_account_numbers)"
+        str, "Account hash for the Schwab account (from get_accounts)"
     ],
     max_results: Annotated[int | None, "Maximum number of orders to return"] = None,
     from_date: Annotated[

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -12,7 +12,7 @@ from schwab_mcp.tools.utils import JSONType, call, parse_date
 async def get_transactions(
     ctx: SchwabContext,
     account_hash: Annotated[
-        str, "Account hash for the Schwab account (from get_account_numbers)"
+        str, "Account hash for the Schwab account (from get_accounts)"
     ],
     start_date: Annotated[
         str | None,

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from enum import Enum
 from types import SimpleNamespace
 from typing import Any
-
 from schwab_mcp.tools import account
 from conftest import make_ctx, run
 
@@ -82,40 +81,215 @@ _RAW_LIST_WITH_POSITIONS = [{"securitiesAccount": _RAW_SEC_ACCOUNT_WITH_POSITION
 _RAW_DICT_PAYLOAD = {"securitiesAccount": _RAW_SEC_ACCOUNT}
 _RAW_DICT_WITH_POSITIONS = {"securitiesAccount": _RAW_SEC_ACCOUNT_WITH_POSITIONS}
 
+_SAMPLE_IDENTITY_MAP: dict[str, account.AccountIdentity] = {
+    "123": account.AccountIdentity(account_hash="hash_abc", nickname="My Margin"),
+}
 
-class TestGetAccountNumbers:
-    def test_calls_client_method(self, monkeypatch, fake_call_factory):
-        captured, fake_call = fake_call_factory(
-            return_value=[{"accountNumber": "123", "hashValue": "abc123"}]
-        )
+
+# ---------------------------------------------------------------------------
+# Tests for _get_identity_map
+# ---------------------------------------------------------------------------
+
+
+class TestGetIdentityMap:
+    def test_builds_map_from_numbers_and_prefs(self, monkeypatch):
+        numbers_payload = [{"accountNumber": "123", "hashValue": "hash_abc"}]
+        prefs_payload = {
+            "accounts": [{"accountNumber": "123", "nickName": "My Margin"}]
+        }
+        call_returns = iter([numbers_payload, prefs_payload])
+
+        async def fake_call(func, *args, **kwargs):
+            return next(call_returns)
 
         monkeypatch.setattr(account, "call", fake_call)
-
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account_numbers(ctx))
+        result = run(account._get_identity_map(ctx))
 
-        assert result == [{"accountNumber": "123", "hashValue": "abc123"}]
-        assert captured["func"].__name__ == "get_account_numbers"
+        assert result == {
+            "123": account.AccountIdentity(
+                account_hash="hash_abc", nickname="My Margin"
+            )
+        }
+
+    def test_missing_nickname_yields_none(self, monkeypatch):
+        numbers_payload = [{"accountNumber": "456", "hashValue": "hash_def"}]
+        prefs_payload = {"accounts": []}  # no entry for 456
+        call_returns = iter([numbers_payload, prefs_payload])
+
+        async def fake_call(func, *args, **kwargs):
+            return next(call_returns)
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert result == {
+            "456": account.AccountIdentity(account_hash="hash_def", nickname=None)
+        }
+
+    def test_empty_payloads_yield_empty_map(self, monkeypatch):
+        async def fake_call(func, *args, **kwargs):
+            return None
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert result == {}
+
+    def test_malformed_numbers_entry_skipped(self, monkeypatch):
+        numbers_payload = [
+            {"accountNumber": "123"},  # missing hashValue
+            "not-a-dict",
+            {"accountNumber": "456", "hashValue": "hash_def"},
+        ]
+        prefs_payload = {}
+        call_returns = iter([numbers_payload, prefs_payload])
+
+        async def fake_call(func, *args, **kwargs):
+            return next(call_returns)
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert "123" not in result  # missing hashValue skipped
+        assert result["456"].account_hash == "hash_def"
+
+    def test_non_string_nickname_normalized_to_none(self, monkeypatch):
+        numbers_payload = [{"accountNumber": "123", "hashValue": "hash_abc"}]
+        prefs_payload = {"accounts": [{"accountNumber": "123", "nickName": 12345}]}
+        call_returns = iter([numbers_payload, prefs_payload])
+
+        async def fake_call(func, *args, **kwargs):
+            return next(call_returns)
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert result["123"].nickname is None
+
+    def test_api_error_is_best_effort_and_yields_empty_map(self, monkeypatch):
+        from schwab_mcp.tools.utils import SchwabAPIError
+
+        async def fake_call(func, *args, **kwargs):
+            raise SchwabAPIError(status_code=500, url="https://example.com", body="")
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _enrich_with_identity
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichWithIdentity:
+    def test_list_shape_injects_fields(self):
+        payload = [{"securitiesAccount": {"accountNumber": "123"}}]
+        result = account._enrich_with_identity(payload, _SAMPLE_IDENTITY_MAP)
+        assert isinstance(result, list)
+        sec = result[0]["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_dict_shape_injects_fields(self):
+        payload = {"securitiesAccount": {"accountNumber": "123"}}
+        result = account._enrich_with_identity(payload, _SAMPLE_IDENTITY_MAP)
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_no_match_yields_null_fields(self):
+        payload = {"securitiesAccount": {"accountNumber": "UNKNOWN"}}
+        result = account._enrich_with_identity(payload, _SAMPLE_IDENTITY_MAP)
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] is None
+        assert sec["nickname"] is None
+
+    def test_null_fields_always_present(self):
+        """Both keys must be present even when identity map is empty."""
+        payload = {"securitiesAccount": {"accountNumber": "999"}}
+        result = account._enrich_with_identity(payload, {})
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert "accountHash" in sec
+        assert "nickname" in sec
+        assert sec["accountHash"] is None
+        assert sec["nickname"] is None
+
+    def test_list_item_without_securities_account_passes_through(self):
+        payload = [{"other": "data"}, {"securitiesAccount": {"accountNumber": "123"}}]
+        result = account._enrich_with_identity(payload, _SAMPLE_IDENTITY_MAP)
+        assert isinstance(result, list)
+        assert result[0] == {"other": "data"}
+        assert result[1]["securitiesAccount"]["accountHash"] == "hash_abc"
+
+    def test_fallback_hash_used_when_no_match(self):
+        payload = {"securitiesAccount": {"accountNumber": "UNKNOWN"}}
+        result = account._enrich_with_identity(
+            payload, {}, fallback_hash="requested_hash"
+        )
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "requested_hash"
+        assert sec["nickname"] is None
+
+    def test_fallback_hash_ignored_when_match_found(self):
+        payload = {"securitiesAccount": {"accountNumber": "123"}}
+        result = account._enrich_with_identity(
+            payload, _SAMPLE_IDENTITY_MAP, fallback_hash="requested_hash"
+        )
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+
+
+# ---------------------------------------------------------------------------
+# TestGetAccounts — monkeypatch _get_identity_map for pruning/verbose tests
+# ---------------------------------------------------------------------------
 
 
 class TestGetAccounts:
+    def _patch_identity(self, monkeypatch, identity_map=None):
+        if identity_map is None:
+            identity_map = _SAMPLE_IDENTITY_MAP
+
+        async def fake_get_identity_map(ctx):
+            return identity_map
+
+        monkeypatch.setattr(account, "_get_identity_map", fake_get_identity_map)
+
     def test_calls_client_method(self, monkeypatch, fake_call_factory):
         captured, fake_call = fake_call_factory(
             return_value=[{"securitiesAccount": {"accountNumber": "123"}}]
         )
-
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
         result = run(account.get_accounts(ctx, verbose=True))
 
-        assert result == [{"securitiesAccount": {"accountNumber": "123"}}]
+        assert isinstance(result, list)
         assert captured["func"].__name__ == "get_accounts"
 
     def test_compact_default_strips_extra_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -124,33 +298,61 @@ class TestGetAccounts:
 
         assert isinstance(result, list)
         sec = result[0]["securitiesAccount"]
-        # identity fields kept
         assert sec["accountNumber"] == "123"
         assert sec["type"] == "MARGIN"
-        # initialBalances / projectedBalances dropped
         assert "initialBalances" not in sec
         assert "projectedBalances" not in sec
-        # only allowlisted balance fields
         balances = sec["currentBalances"]
         assert set(balances.keys()) <= account._COMPACT_BALANCE_FIELDS
         assert "maintenanceRequirement" not in balances
         assert "totalCash" not in balances
         assert balances["equity"] == 50000.0
 
-    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+    def test_compact_includes_identity_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        self._patch_identity(monkeypatch)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts(ctx))
+
+        sec = result[0]["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_verbose_includes_identity_fields(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
         result = run(account.get_accounts(ctx, verbose=True))
 
-        assert result is _RAW_LIST_PAYLOAD
+        assert isinstance(result, list)
+        sec = result[0]["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_no_identity_match_yields_null_fields(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        self._patch_identity(monkeypatch, identity_map={})
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_accounts(ctx))
+
+        sec = result[0]["securitiesAccount"]
+        assert sec["accountHash"] is None
+        assert sec["nickname"] is None
 
     def test_default_does_not_request_positions_field(
         self, monkeypatch, fake_call_factory
     ):
         captured, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -163,16 +365,18 @@ class TestGetAccounts:
         self, monkeypatch, fake_call_factory
     ):
         captured, fake_call = fake_call_factory(
-            return_value=[{"securitiesAccount": {"positions": []}}]
+            return_value=[
+                {"securitiesAccount": {"accountNumber": "123", "positions": []}}
+            ]
         )
-
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
         result = run(account.get_accounts(ctx, include_positions=True, verbose=True))
 
-        assert result == [{"securitiesAccount": {"positions": []}}]
+        assert isinstance(result, list)
         assert captured["func"].__name__ == "get_accounts"
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
 
@@ -180,6 +384,7 @@ class TestGetAccounts:
         self, monkeypatch, fake_call_factory
     ):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -194,49 +399,68 @@ class TestGetAccounts:
         assert len(positions) == 1
         pos = positions[0]
         assert pos["symbol"] == "AAPL"
-        assert pos["quantity"] == 10  # longQuantity 10 - shortQuantity 0
+        assert pos["quantity"] == 10
         assert pos["marketValue"] == 1550.0
         assert pos["averagePrice"] == 150.0
         assert pos["unrealizedPL"] == 100.0
         assert "settledLongQuantity" not in pos
         assert "maintenanceRequirement" not in pos
 
-    def test_include_positions_verbose_returns_raw_payload(
+    def test_include_positions_verbose_returns_enriched_payload(
         self, monkeypatch, fake_call_factory
     ):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_WITH_POSITIONS)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
         result = run(account.get_accounts(ctx, include_positions=True, verbose=True))
 
-        assert result is _RAW_LIST_WITH_POSITIONS
+        assert isinstance(result, list)
+        # enrichment still applied in verbose mode
+        sec = result[0]["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+
+
+# ---------------------------------------------------------------------------
+# TestGetAccount — monkeypatch _get_identity_map for pruning/verbose tests
+# ---------------------------------------------------------------------------
 
 
 class TestGetAccount:
+    def _patch_identity(self, monkeypatch, identity_map=None):
+        if identity_map is None:
+            identity_map = _SAMPLE_IDENTITY_MAP
+
+        async def fake_get_identity_map(ctx):
+            return identity_map
+
+        monkeypatch.setattr(account, "_get_identity_map", fake_get_identity_map)
+
     def test_calls_client_with_account_hash(self, monkeypatch, fake_call_factory):
         captured, fake_call = fake_call_factory(
-            return_value={"securitiesAccount": {"accountNumber": "456"}}
+            return_value={"securitiesAccount": {"accountNumber": "123"}}
         )
-
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account(ctx, "hash456", verbose=True))
+        result = run(account.get_account(ctx, "hash_abc", verbose=True))
 
-        assert result == {"securitiesAccount": {"accountNumber": "456"}}
+        assert isinstance(result, dict)
         assert captured["func"].__name__ == "get_account"
-        assert captured["args"] == ("hash456",)
+        assert captured["args"] == ("hash_abc",)
 
     def test_compact_default_strips_extra_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account(ctx, "hash456"))
+        result = run(account.get_account(ctx, "hash_abc"))
 
         assert isinstance(result, dict)
         sec = result["securitiesAccount"]
@@ -247,25 +471,59 @@ class TestGetAccount:
         assert set(balances.keys()) <= account._COMPACT_BALANCE_FIELDS
         assert "maintenanceRequirement" not in balances
 
-    def test_verbose_returns_raw_payload(self, monkeypatch, fake_call_factory):
+    def test_compact_includes_identity_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        result = run(account.get_account(ctx, "hash456", verbose=True))
+        result = run(account.get_account(ctx, "hash_abc"))
 
-        assert result is _RAW_DICT_PAYLOAD
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_verbose_includes_identity_fields(self, monkeypatch, fake_call_factory):
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        self._patch_identity(monkeypatch)
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account(ctx, "hash_abc", verbose=True))
+
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] == "My Margin"
+
+    def test_no_identity_match_falls_back_to_requested_hash(
+        self, monkeypatch, fake_call_factory
+    ):
+        """get_account() already knows account_hash; enrichment falling short
+        should not discard it."""
+        _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        self._patch_identity(monkeypatch, identity_map={})
+        monkeypatch.setattr(account, "call", fake_call)
+
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account.get_account(ctx, "hash_abc"))
+
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
+        assert sec["nickname"] is None
 
     def test_default_does_not_request_positions_field(
         self, monkeypatch, fake_call_factory
     ):
         captured, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
         ctx = make_ctx(client)
-        run(account.get_account(ctx, "hash456"))
+        run(account.get_account(ctx, "hash_abc"))
 
         assert "fields" not in captured["kwargs"]
 
@@ -273,9 +531,14 @@ class TestGetAccount:
         self, monkeypatch, fake_call_factory
     ):
         captured, fake_call = fake_call_factory(
-            return_value={"securitiesAccount": {"positions": [{"symbol": "SPY"}]}}
+            return_value={
+                "securitiesAccount": {
+                    "accountNumber": "123",
+                    "positions": [{"symbol": "SPY"}],
+                }
+            }
         )
-
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -284,7 +547,7 @@ class TestGetAccount:
             account.get_account(ctx, "hash789", include_positions=True, verbose=True)
         )
 
-        assert result == {"securitiesAccount": {"positions": [{"symbol": "SPY"}]}}
+        assert isinstance(result, dict)
         assert captured["func"].__name__ == "get_account"
         assert captured["args"] == ("hash789",)
         assert captured["kwargs"]["fields"] == [client.Account.Fields.POSITIONS]
@@ -293,6 +556,7 @@ class TestGetAccount:
         self, monkeypatch, fake_call_factory
     ):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -313,10 +577,11 @@ class TestGetAccount:
         assert pos["unrealizedPL"] == 100.0
         assert "settledLongQuantity" not in pos
 
-    def test_include_positions_verbose_returns_raw_payload(
+    def test_include_positions_verbose_returns_enriched_payload(
         self, monkeypatch, fake_call_factory
     ):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_WITH_POSITIONS)
+        self._patch_identity(monkeypatch)
         monkeypatch.setattr(account, "call", fake_call)
 
         client = DummyAccountClient()
@@ -325,23 +590,9 @@ class TestGetAccount:
             account.get_account(ctx, "hash789", include_positions=True, verbose=True)
         )
 
-        assert result is _RAW_DICT_WITH_POSITIONS
-
-
-class TestGetUserPreferences:
-    def test_calls_client_method(self, monkeypatch, fake_call_factory):
-        captured, fake_call = fake_call_factory(
-            return_value={"accounts": [{"displayAcctId": "...1234"}]}
-        )
-
-        monkeypatch.setattr(account, "call", fake_call)
-
-        client = DummyAccountClient()
-        ctx = make_ctx(client)
-        result = run(account.get_user_preferences(ctx))
-
-        assert result == {"accounts": [{"displayAcctId": "...1234"}]}
-        assert captured["func"].__name__ == "get_user_preferences"
+        assert isinstance(result, dict)
+        sec = result["securitiesAccount"]
+        assert sec["accountHash"] == "hash_abc"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`get_account_numbers` and `get_user_preferences` were two extra tools an LLM had to learn and call just to answer "what accounts do I have, and what's their hash/nickname?" That's Schwab API plumbing leaking into the tool surface, not something a caller actually needs to reason about separately.

`get_accounts()`/`get_account()` now resolve that internally and embed `accountHash` + `nickname` directly on each account, in both compact and verbose modes. `get_account_numbers`/`get_user_preferences` are no longer registered as MCP tools at all (`_READ_ONLY_TOOLS` goes from 4 entries down to 2) - their API calls now happen only inside a new internal `_get_identity_map()` helper that joins Schwab's `accountNumbers` and `userPreference` endpoints by account number.

- `_get_identity_map()` returns `dict[str, AccountIdentity]`, a small frozen dataclass (`account_hash`, `nickname`), matching the dataclass style already used in `context.py`/`approvals/`
- `_enrich_with_identity()` injects `accountHash`/`nickname` onto each `securitiesAccount` entry, handling both the list (`get_accounts`) and single-dict (`get_account`) response shapes; both fields are always present (`null` if unresolved) rather than silently omitted
- no caching - these are low-frequency, interactive tool calls, so two extra internal API calls per invocation isn't worth the complexity
- updated the `account_hash` docstrings in `orders.py`/`transactions.py` that used to point at `get_account_numbers`

## Testing

- `ruff format --check .`, `ruff check .`, `pyright`, `pytest` all pass (387 tests, no regressions)
- `tests/test_account.py` adds dedicated coverage for `_get_identity_map` (join behavior, missing nickname, malformed/empty payloads) and `_enrich_with_identity` (list/dict shapes, no-match → null), plus updated `get_accounts`/`get_account` tests asserting the enriched fields in both compact and verbose modes
