### PR TITLE
feat(tools): surface isDefault flag on account identity

### DIFF
--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -29,6 +29,7 @@ _COMPACT_BALANCE_FIELDS = frozenset(
 class AccountIdentity:
     account_hash: str
     nickname: str | None
+    is_default: bool
 
 
 def _prune_position(position: dict[str, Any]) -> dict[str, Any]:
@@ -100,7 +101,7 @@ async def _get_identity_map(ctx: SchwabContext) -> dict[str, AccountIdentity]:
 
     Identity enrichment is best-effort metadata: if either upstream endpoint
     fails, callers still get their primary account/balance data, just without
-    accountHash/nickname enrichment (an empty map is returned).
+    accountHash/nickname/isDefault enrichment (an empty map is returned).
     """
     try:
         numbers_payload = await call(ctx.accounts.get_account_numbers)
@@ -119,18 +120,24 @@ async def _get_identity_map(ctx: SchwabContext) -> dict[str, AccountIdentity]:
     accounts = (
         prefs_payload.get("accounts") if isinstance(prefs_payload, dict) else None
     )
-    nick_map: dict[str, str | None] = {
-        acct["accountNumber"]: acct.get("nickName")
-        if isinstance(acct.get("nickName"), str)
-        else None
-        for acct in (accounts if isinstance(accounts, list) else [])
-        if isinstance(acct, dict) and isinstance(acct.get("accountNumber"), str)
-    }
+    nick_map: dict[str, str | None] = {}
+    default_map: dict[str, bool] = {}
+    for acct in accounts if isinstance(accounts, list) else []:
+        if not isinstance(acct, dict):
+            continue
+        acct_num = acct.get("accountNumber")
+        if not isinstance(acct_num, str):
+            continue
+        nick_map[acct_num] = (
+            acct.get("nickName") if isinstance(acct.get("nickName"), str) else None
+        )
+        default_map[acct_num] = acct.get("primaryAccount") is True
 
     return {
         acct_num: AccountIdentity(
             account_hash=hash_val,
             nickname=nick_map.get(acct_num),
+            is_default=default_map.get(acct_num, False),
         )
         for acct_num, hash_val in hash_map.items()
     }
@@ -142,12 +149,12 @@ def _enrich_with_identity(
     *,
     fallback_hash: str | None = None,
 ) -> JSONType:
-    """Inject accountHash and nickname into each securitiesAccount dict.
+    """Inject accountHash, nickname, and isDefault into each securitiesAccount dict.
 
     Handles both list-of-accounts and single-account dict shapes.
-    Always sets both keys; falls back to fallback_hash (typically the
+    Always sets all three keys; falls back to fallback_hash (typically the
     account_hash the caller already supplied) if no identity-map entry is
-    found, and uses None for nickname in that case.
+    found, and uses None for nickname and False for isDefault in that case.
     """
 
     def _enrich_sec(sec: dict[str, Any]) -> None:
@@ -155,6 +162,7 @@ def _enrich_with_identity(
         identity = identity_map.get(acct_num) if isinstance(acct_num, str) else None
         sec["accountHash"] = identity.account_hash if identity else fallback_hash
         sec["nickname"] = identity.nickname if identity else None
+        sec["isDefault"] = identity.is_default if identity else False
 
     if isinstance(payload, list):
         for item in payload:
@@ -185,7 +193,7 @@ async def get_accounts(
 ) -> JSONType:
     """
     Returns balances/info for all linked accounts (funds, cash, margin); pass include_positions=True to also include holdings.
-    Includes each account's accountHash (required for account-specific calls like get_account, orders, transactions) and nickname.
+    Includes each account's accountHash (required for account-specific calls like get_account, orders, transactions), nickname, and isDefault (the account marked as primary in Schwab user preferences).
     By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
     identity_map = await _get_identity_map(ctx)
@@ -213,7 +221,7 @@ async def get_account(
 ) -> JSONType:
     """
     Returns balance/info for a specific account via account_hash (from get_accounts); pass include_positions=True to also include holdings. Includes funds, cash, margin info.
-    Includes the account's accountHash and nickname for self-describing output.
+    Includes the account's accountHash, nickname, and isDefault for self-describing output.
     By default returns compact fields only (account type/number, equity/buyingPower/cashBalance/cashAvailableForTrading/liquidationValue from currentBalances; initialBalances and projectedBalances are dropped; positions if included are reduced to symbol, net quantity (positive=long/negative=short), marketValue, averagePrice, unrealizedPL); pass verbose=True for the full raw payload (positions unpruned if include_positions=True).
     """
     identity_map = await _get_identity_map(ctx)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -82,7 +82,9 @@ _RAW_DICT_PAYLOAD = {"securitiesAccount": _RAW_SEC_ACCOUNT}
 _RAW_DICT_WITH_POSITIONS = {"securitiesAccount": _RAW_SEC_ACCOUNT_WITH_POSITIONS}
 
 _SAMPLE_IDENTITY_MAP: dict[str, account.AccountIdentity] = {
-    "123": account.AccountIdentity(account_hash="hash_abc", nickname="My Margin"),
+    "123": account.AccountIdentity(
+        account_hash="hash_abc", nickname="My Margin", is_default=False
+    ),
 }
 
 
@@ -95,7 +97,13 @@ class TestGetIdentityMap:
     def test_builds_map_from_numbers_and_prefs(self, monkeypatch):
         numbers_payload = [{"accountNumber": "123", "hashValue": "hash_abc"}]
         prefs_payload = {
-            "accounts": [{"accountNumber": "123", "nickName": "My Margin"}]
+            "accounts": [
+                {
+                    "accountNumber": "123",
+                    "nickName": "My Margin",
+                    "primaryAccount": True,
+                }
+            ]
         }
         call_returns = iter([numbers_payload, prefs_payload])
 
@@ -109,7 +117,7 @@ class TestGetIdentityMap:
 
         assert result == {
             "123": account.AccountIdentity(
-                account_hash="hash_abc", nickname="My Margin"
+                account_hash="hash_abc", nickname="My Margin", is_default=True
             )
         }
 
@@ -127,7 +135,9 @@ class TestGetIdentityMap:
         result = run(account._get_identity_map(ctx))
 
         assert result == {
-            "456": account.AccountIdentity(account_hash="hash_def", nickname=None)
+            "456": account.AccountIdentity(
+                account_hash="hash_def", nickname=None, is_default=False
+            )
         }
 
     def test_empty_payloads_yield_empty_map(self, monkeypatch):
@@ -176,6 +186,36 @@ class TestGetIdentityMap:
 
         assert result["123"].nickname is None
 
+    def test_identity_map_defaults_false_when_primary_account_missing_or_false(
+        self, monkeypatch
+    ):
+        numbers_payload = [
+            {"accountNumber": "123", "hashValue": "hash_abc"},
+            {"accountNumber": "456", "hashValue": "hash_def"},
+        ]
+        prefs_payload = {
+            "accounts": [
+                {"accountNumber": "123", "nickName": "No Primary"},  # key absent
+                {
+                    "accountNumber": "456",
+                    "nickName": "False Primary",
+                    "primaryAccount": False,
+                },
+            ]
+        }
+        call_returns = iter([numbers_payload, prefs_payload])
+
+        async def fake_call(func, *args, **kwargs):
+            return next(call_returns)
+
+        monkeypatch.setattr(account, "call", fake_call)
+        client = DummyAccountClient()
+        ctx = make_ctx(client)
+        result = run(account._get_identity_map(ctx))
+
+        assert result["123"].is_default is False
+        assert result["456"].is_default is False
+
     def test_api_error_is_best_effort_and_yields_empty_map(self, monkeypatch):
         from schwab_mcp.tools.utils import SchwabAPIError
 
@@ -203,6 +243,7 @@ class TestEnrichWithIdentity:
         sec = result[0]["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] == _SAMPLE_IDENTITY_MAP["123"].is_default
 
     def test_dict_shape_injects_fields(self):
         payload = {"securitiesAccount": {"accountNumber": "123"}}
@@ -211,6 +252,7 @@ class TestEnrichWithIdentity:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] == _SAMPLE_IDENTITY_MAP["123"].is_default
 
     def test_no_match_yields_null_fields(self):
         payload = {"securitiesAccount": {"accountNumber": "UNKNOWN"}}
@@ -219,17 +261,20 @@ class TestEnrichWithIdentity:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] is None
         assert sec["nickname"] is None
+        assert sec["isDefault"] is False
 
     def test_null_fields_always_present(self):
-        """Both keys must be present even when identity map is empty."""
+        """All three keys must be present even when identity map is empty."""
         payload = {"securitiesAccount": {"accountNumber": "999"}}
         result = account._enrich_with_identity(payload, {})
         assert isinstance(result, dict)
         sec = result["securitiesAccount"]
         assert "accountHash" in sec
         assert "nickname" in sec
+        assert "isDefault" in sec
         assert sec["accountHash"] is None
         assert sec["nickname"] is None
+        assert sec["isDefault"] is False
 
     def test_list_item_without_securities_account_passes_through(self):
         payload = [{"other": "data"}, {"securitiesAccount": {"accountNumber": "123"}}]
@@ -247,6 +292,7 @@ class TestEnrichWithIdentity:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] == "requested_hash"
         assert sec["nickname"] is None
+        assert sec["isDefault"] is False
 
     def test_fallback_hash_ignored_when_match_found(self):
         payload = {"securitiesAccount": {"accountNumber": "123"}}
@@ -320,6 +366,7 @@ class TestGetAccounts:
         sec = result[0]["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] is False
 
     def test_verbose_includes_identity_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
@@ -334,6 +381,7 @@ class TestGetAccounts:
         sec = result[0]["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] is False
 
     def test_no_identity_match_yields_null_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_LIST_PAYLOAD)
@@ -347,6 +395,7 @@ class TestGetAccounts:
         sec = result[0]["securitiesAccount"]
         assert sec["accountHash"] is None
         assert sec["nickname"] is None
+        assert sec["isDefault"] is False
 
     def test_default_does_not_request_positions_field(
         self, monkeypatch, fake_call_factory
@@ -483,6 +532,7 @@ class TestGetAccount:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] is False
 
     def test_verbose_includes_identity_fields(self, monkeypatch, fake_call_factory):
         _, fake_call = fake_call_factory(return_value=_RAW_DICT_PAYLOAD)
@@ -496,6 +546,7 @@ class TestGetAccount:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] == "My Margin"
+        assert sec["isDefault"] is False
 
     def test_no_identity_match_falls_back_to_requested_hash(
         self, monkeypatch, fake_call_factory
@@ -513,6 +564,7 @@ class TestGetAccount:
         sec = result["securitiesAccount"]
         assert sec["accountHash"] == "hash_abc"
         assert sec["nickname"] is None
+        assert sec["isDefault"] is False
 
     def test_default_does_not_request_positions_field(
         self, monkeypatch, fake_call_factory


### PR DESCRIPTION
`get_accounts`/`get_account` already enrich each account with `accountHash` and `nickname` by cross-referencing `get_account_numbers` and `get_user_preferences`, but they silently dropped Schwab's `primaryAccount` flag from the preferences payload, so there was no way to tell which linked account is the user's default.

This adds an `isDefault` boolean alongside the existing enrichment fields, sourced from `primaryAccount` in `get_user_preferences`. It defaults to `False` when identity enrichment can't find a match (upstream failure or unknown account number), same fallback behavior as the existing `nickname` field.

- `AccountIdentity` gains `is_default: bool`
- `_get_identity_map` parses `primaryAccount` per account entry
- `_enrich_with_identity` injects `isDefault` into each `securitiesAccount` dict
- tests cover identity-map building and enrichment for the new field

No API surface changes beyond the new response key; existing callers are unaffected.
