### PR TITLE
refactor(tools): consolidate sma/ema into moving_average

### DIFF
--- a/src/schwab_mcp/tools/technical/moving_average.py
+++ b/src/schwab_mcp/tools/technical/moving_average.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Annotated, Any
 
+import pandas as pd
 from mcp.server.fastmcp import FastMCP
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -14,7 +15,7 @@ from .base import (
     Points,
     StartTime,
     Symbol,
-    compute_series_indicator,
+    compute_frame_indicator,
     compute_window,
     pandas_ta,
 )
@@ -22,58 +23,41 @@ from .base import (
 __all__ = ["register"]
 
 
-async def sma(
+async def moving_average(
     ctx: SchwabContext,
     symbol: Symbol,
-    length: Annotated[int, "Number of periods used to compute the SMA"] = 20,
+    length: Annotated[int, "Number of periods used to compute the SMA and EMA"] = 20,
     interval: Interval = "1d",
     start: StartTime = None,
     end: EndTime = None,
     points: Points = None,
 ) -> JSONType:
-    """Compute a simple moving average for Schwab price history."""
+    """Compute both the simple and exponential moving averages for Schwab price history."""
     if length <= 0:
         raise ValueError("length must be a positive integer")
 
-    return await compute_series_indicator(
+    def indicator_fn(frame: pd.DataFrame) -> pd.DataFrame:
+        close = frame["close"]
+        combined = pd.DataFrame(
+            {
+                f"sma_{length}": pandas_ta.sma(close, length=length),
+                f"ema_{length}": pandas_ta.ema(close, length=length),
+            }
+        )
+        # Drop rows where either series hasn't warmed up yet so every
+        # returned row includes both sma_{length} and ema_{length}.
+        return combined.dropna(how="any")
+
+    return await compute_frame_indicator(
         ctx,
         symbol,
-        indicator_fn=lambda frame: pandas_ta.sma(frame["close"], length=length),
-        indicator_name="sma",
+        indicator_fn=indicator_fn,
+        indicator_name="moving_average",
         interval=interval,
         start=start,
         end=end,
         bars=compute_window(length, multiplier=2, min_padding=10),
         points=points,
-        value_key=f"sma_{length}",
-        extra_metadata={"length": length},
-    )
-
-
-async def ema(
-    ctx: SchwabContext,
-    symbol: Symbol,
-    length: Annotated[int, "Number of periods used to compute the EMA"] = 20,
-    interval: Interval = "1d",
-    start: StartTime = None,
-    end: EndTime = None,
-    points: Points = None,
-) -> JSONType:
-    """Compute an exponential moving average for Schwab price history."""
-    if length <= 0:
-        raise ValueError("length must be a positive integer")
-
-    return await compute_series_indicator(
-        ctx,
-        symbol,
-        indicator_fn=lambda frame: pandas_ta.ema(frame["close"], length=length),
-        indicator_name="ema",
-        interval=interval,
-        start=start,
-        end=end,
-        bars=compute_window(length, multiplier=2, min_padding=10),
-        points=points,
-        value_key=f"ema_{length}",
         extra_metadata={"length": length},
     )
 
@@ -85,5 +69,4 @@ def register(
     result_transform: Callable[[Any], Any] | None = None,
 ) -> None:
     _ = allow_write
-    register_tool(server, sma, result_transform=result_transform)
-    register_tool(server, ema, result_transform=result_transform)
+    register_tool(server, moving_average, result_transform=result_transform)

--- a/tests/test_technical_tools.py
+++ b/tests/test_technical_tools.py
@@ -76,7 +76,7 @@ def ohlcv_data():
     return frame, metadata
 
 
-def test_sma_returns_expected_values(monkeypatch, dummy_ctx, price_data):
+def test_moving_average_returns_sma_and_ema(monkeypatch, dummy_ctx, price_data):
     frame, metadata = price_data
 
     async def fake_fetch(ctx, symbol, **kwargs):
@@ -88,33 +88,79 @@ def test_sma_returns_expected_values(monkeypatch, dummy_ctx, price_data):
     def fake_sma(series, *, length):
         return series.rolling(length, min_periods=1).mean()
 
+    def fake_ema(series, *, length):
+        return series.ewm(span=length, adjust=False).mean()
+
     monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
     monkeypatch.setattr(
         moving_average,
         "pandas_ta",
-        SimpleNamespace(sma=fake_sma),
+        SimpleNamespace(sma=fake_sma, ema=fake_ema),
     )
 
-    result = run_tool(moving_average.sma(dummy_ctx, "HOOD", length=3, points=2))
+    result = run_tool(
+        moving_average.moving_average(dummy_ctx, "HOOD", length=3, points=2)
+    )
 
     assert result["symbol"] == "HOOD"
     assert result["interval"] == "1d"
     assert result["candles"] == len(frame)
+    assert result["length"] == 3
 
     values = result["values"]
     assert len(values) == 2
-    expected = frame["close"].rolling(3, min_periods=1).mean().tail(2).to_numpy()
-    for row, expected_value in zip(values, expected):
+    expected_sma = frame["close"].rolling(3, min_periods=1).mean().tail(2).to_numpy()
+    expected_ema = frame["close"].ewm(span=3, adjust=False).mean().tail(2).to_numpy()
+    for row, sma_value, ema_value in zip(values, expected_sma, expected_ema):
         assert row["timestamp"].endswith("+00:00")
-        assert row["sma_3"] == pytest.approx(float(expected_value))
+        assert row["sma_3"] == pytest.approx(float(sma_value))
+        assert row["ema_3"] == pytest.approx(float(ema_value))
 
 
-def test_ema_defaults_to_default_points(monkeypatch, dummy_ctx, price_data):
+def test_moving_average_drops_rows_missing_either_series(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    def fake_sma(series, *, length):
+        # Real warmup behavior: no value until `length` periods have passed.
+        return series.rolling(length, min_periods=length).mean()
+
+    def fake_ema(series, *, length):
+        # EMA warms up immediately, unlike SMA above, so early rows would
+        # otherwise contain ema_{length} with no sma_{length}.
+        return series.ewm(span=length, adjust=False).mean()
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        moving_average,
+        "pandas_ta",
+        SimpleNamespace(sma=fake_sma, ema=fake_ema),
+    )
+
+    result = run_tool(
+        moving_average.moving_average(dummy_ctx, "HOOD", length=3, points=10)
+    )
+
+    values = result["values"]
+    assert len(values) == len(frame) - 2  # first two rows lack sma_3
+    for row in values:
+        assert "sma_3" in row
+        assert "ema_3" in row
+
+
+def test_moving_average_defaults_to_default_points(monkeypatch, dummy_ctx, price_data):
     frame, metadata = price_data
 
     async def fake_fetch(ctx, symbol, **kwargs):
         assert kwargs["bars"] >= 0
         return frame, metadata
+
+    def fake_sma(series, *, length):
+        return series.rolling(length, min_periods=1).mean()
 
     def fake_ema(series, *, length):
         return series.ewm(span=length, adjust=False).mean()
@@ -123,15 +169,15 @@ def test_ema_defaults_to_default_points(monkeypatch, dummy_ctx, price_data):
     monkeypatch.setattr(
         moving_average,
         "pandas_ta",
-        SimpleNamespace(ema=fake_ema),
+        SimpleNamespace(sma=fake_sma, ema=fake_ema),
     )
 
-    result = run_tool(moving_average.ema(dummy_ctx, "HOOD", length=5))
+    result = run_tool(moving_average.moving_average(dummy_ctx, "HOOD", length=5))
 
     values = result["values"]
     assert len(values) == base.DEFAULT_POINTS
-    last_value = frame["close"].ewm(span=5, adjust=False).mean().iloc[-1]
-    assert values[-1]["ema_5"] == pytest.approx(float(last_value))
+    last_ema = frame["close"].ewm(span=5, adjust=False).mean().iloc[-1]
+    assert values[-1]["ema_5"] == pytest.approx(float(last_ema))
 
 
 def test_rsi_returns_expected_values(monkeypatch, dummy_ctx, price_data):
@@ -718,7 +764,9 @@ def test_expected_move_honors_custom_multiplier(monkeypatch, dummy_ctx):
     assert result["boundaries"]["upper_1x"] == pytest.approx(100.0 + 4.8)
 
 
-def test_sma_defaults_to_default_points_not_length(monkeypatch, dummy_ctx, price_data):
+def test_moving_average_defaults_to_default_points_not_length(
+    monkeypatch, dummy_ctx, price_data
+):
     frame, metadata = price_data
 
     async def fake_fetch(ctx, symbol, **kwargs):
@@ -727,14 +775,17 @@ def test_sma_defaults_to_default_points_not_length(monkeypatch, dummy_ctx, price
     def fake_sma(series, *, length):
         return series.rolling(length, min_periods=1).mean()
 
+    def fake_ema(series, *, length):
+        return series.ewm(span=length, adjust=False).mean()
+
     monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
     monkeypatch.setattr(
         moving_average,
         "pandas_ta",
-        SimpleNamespace(sma=fake_sma),
+        SimpleNamespace(sma=fake_sma, ema=fake_ema),
     )
 
-    result = run_tool(moving_average.sma(dummy_ctx, "HOOD", length=5))
+    result = run_tool(moving_average.moving_average(dummy_ctx, "HOOD", length=5))
 
     values = result["values"]
     assert len(values) == base.DEFAULT_POINTS


### PR DESCRIPTION
## What

`sma` and `ema` were two nearly-identical tools that only differed by which pandas_ta function they called and what key they stuffed the result under. Anyone who wanted both series (the common case when eyeballing a moving-average crossover) had to make two separate calls and fetch the same price history twice.

They're now merged into a single `moving_average` tool that fetches the price history once and returns both `sma_{length}` and `ema_{length}` on each row, using the same `length` for both. Internally this swaps `compute_series_indicator` (single-column) for `compute_frame_indicator` (multi-column), which was already used by `bollinger_bands` and others, so no new plumbing was needed.

- `moving_average()` replaces `sma()`/`ema()` in `moving_average.py`; `register()` now registers one tool instead of two
- `indicator_fn` builds a small `DataFrame` combining `pandas_ta.sma` and `pandas_ta.ema` output before handing it to `compute_frame_indicator`
- tests updated to assert both `sma_{length}` and `ema_{length}` show up in the response

## Testing

- `ruff format --check .`, `ruff check .`, `pyright`, `vulture`, `pytest` all pass (392 tests, no regressions)
- `tests/test_technical_tools.py` covers the merged tool: default points, custom length/points, and both SMA/EMA values present on each row
