### PR TITLE
fix(orders): return updated order details from cancel_order

### DIFF
--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -42,7 +42,7 @@ from schwab_mcp.tools.order_helpers import (
     option_sell_to_open_limit,
     option_sell_to_open_market,
 )
-from schwab_mcp.tools.utils import JSONType, ResponseHandler, call
+from schwab_mcp.tools.utils import JSONType, ResponseHandler, SchwabAPIError, call
 
 
 _COMPACT_ORDER_TOP_FIELDS = frozenset(
@@ -774,10 +774,24 @@ async def cancel_order(
     order_id: Annotated[str, "Order ID to cancel"],
 ) -> JSONType:
     """
-    Cancels a pending order. Cannot cancel executed/terminal orders. Params: account_hash, order_id. Returns cancellation request confirmation; check status after. *Write operation.*
+    Cancels a pending order. Cannot cancel executed/terminal orders. Params: account_hash, order_id. Returns updated order details (compact/pruned, same shape as get_order) after cancellation; falls back to a minimal {orderId, status, note} payload if the post-cancel status fetch fails or returns no data. *Write operation.*
     """
     client = ctx.orders
-    return await call(client.cancel_order, order_id=order_id, account_hash=account_hash)
+    await call(client.cancel_order, order_id=order_id, account_hash=account_hash)
+    fallback: JSONType = {
+        "orderId": order_id,
+        "status": "PENDING_CANCEL",
+        "note": "Cancel submitted; status fetch failed",
+    }
+    try:
+        result = await call(
+            client.get_order, order_id=order_id, account_hash=account_hash
+        )
+    except SchwabAPIError:
+        return fallback
+    if not isinstance(result, dict):
+        return fallback
+    return _prune_order(result)
 
 
 async def create_option_symbol(

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 
 from schwab_mcp.tools import orders
+from schwab_mcp.tools.utils import SchwabAPIError
 
 from conftest import make_ctx, run
 
@@ -369,12 +370,19 @@ class TestGetOrdersCompact:
 
 class TestCancelOrder:
     def test_calls_client_with_correct_args(self, monkeypatch):
-        captured: dict[str, Any] = {}
+        sample_order = {
+            "orderId": "order456",
+            "status": "CANCELED",
+            "quantity": 10,
+            "filledQuantity": 0,
+        }
+        calls: list[Any] = []
 
         async def fake_call(func, *args, **kwargs):
-            captured["func"] = func
-            captured["kwargs"] = kwargs
-            return None
+            calls.append({"func": func, "kwargs": kwargs})
+            if len(calls) == 1:
+                return None  # cancel_order response
+            return sample_order  # get_order response
 
         monkeypatch.setattr(orders, "call", fake_call)
 
@@ -382,14 +390,103 @@ class TestCancelOrder:
             async def cancel_order(self, *args, **kwargs):
                 return None
 
+            async def get_order(self, *args, **kwargs):
+                return sample_order
+
         client = DummyClient()
         ctx = make_ctx(client)
         result = run(orders.cancel_order(ctx, "hash123", "order456"))
 
-        assert result is None
-        assert captured["func"] == client.cancel_order
-        assert captured["kwargs"]["account_hash"] == "hash123"
-        assert captured["kwargs"]["order_id"] == "order456"
+        assert len(calls) == 2
+        assert calls[0]["func"] == client.cancel_order
+        assert calls[0]["kwargs"]["account_hash"] == "hash123"
+        assert calls[0]["kwargs"]["order_id"] == "order456"
+        assert calls[1]["func"] == client.get_order
+        assert calls[1]["kwargs"]["account_hash"] == "hash123"
+        assert calls[1]["kwargs"]["order_id"] == "order456"
+        # sample_order only contains compact fields, so pruning is a no-op.
+        assert result == sample_order
+
+    def test_returns_fallback_when_get_order_returns_no_data(self, monkeypatch):
+        calls: list[Any] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append(func)
+            if len(calls) == 1:
+                return None  # cancel_order succeeds
+            return None  # get_order returns empty body (e.g. 204)
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        class DummyClient:
+            async def cancel_order(self, *args, **kwargs):
+                return None
+
+            async def get_order(self, *args, **kwargs):
+                return None
+
+        client = DummyClient()
+        ctx = make_ctx(client)
+        result = run(orders.cancel_order(ctx, "hash123", "order456"))
+
+        assert result == {
+            "orderId": "order456",
+            "status": "PENDING_CANCEL",
+            "note": "Cancel submitted; status fetch failed",
+        }
+
+    def test_returns_fallback_when_get_order_fails(self, monkeypatch):
+        calls: list[Any] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append(func)
+            if len(calls) == 1:
+                return None  # cancel_order succeeds
+            raise SchwabAPIError(status_code=404, url="/order", body="not found")
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        class DummyClient:
+            async def cancel_order(self, *args, **kwargs):
+                return None
+
+            async def get_order(self, *args, **kwargs):
+                return None
+
+        client = DummyClient()
+        ctx = make_ctx(client)
+        result = run(orders.cancel_order(ctx, "hash123", "order456"))
+
+        assert result == {
+            "orderId": "order456",
+            "status": "PENDING_CANCEL",
+            "note": "Cancel submitted; status fetch failed",
+        }
+
+    def test_cancel_order_error_propagates_without_get_order(self, monkeypatch):
+        calls: list[Any] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append(func)
+            raise SchwabAPIError(status_code=400, url="/cancel", body="bad request")
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        class DummyClient:
+            async def cancel_order(self, *args, **kwargs):
+                return None
+
+            async def get_order(self, *args, **kwargs):
+                return None
+
+        client = DummyClient()
+        ctx = make_ctx(client)
+
+        with pytest.raises(SchwabAPIError):
+            run(orders.cancel_order(ctx, "hash123", "order456"))
+
+        # Only cancel_order was called, not get_order
+        assert len(calls) == 1
 
 
 class TestPlacePreviewedOrder:


### PR DESCRIPTION
## What

`cancel_order` used to call Schwab's cancel endpoint and hand back whatever came out of `call()` (effectively `None` on success). That forced the LLM caller to immediately turn around and call `get_order` just to see the order's post-cancel status, which was a wasted round trip every time.

Now `cancel_order` cancels the order, then fetches and returns the order details through the same compact/pruned path `get_order` uses, so the caller gets the updated status directly.

## Details

- On successful cancel, fetches the order via `get_order`'s path and returns `_prune_order(result)` — same shape callers already know from `get_order`.
- If the cancel call itself fails, the exception still propagates unchanged (no follow-up fetch is attempted).
- If the cancel succeeds but the follow-up status fetch fails (transient error, race condition, etc.), the failure is swallowed and a minimal fallback is returned instead of masking a cancel that actually worked: `{"orderId", "status": "PENDING_CANCEL", "note": "Cancel submitted; status fetch failed"}`.
- No `verbose` param was added to `cancel_order` — if a caller wants the full raw payload, they can call `get_order(verbose=True)` directly.

## Testing

`uv run pytest` (423 passed), `uv run ruff format . && uv run ruff check .` (clean), `uv run pyright` (0 errors). Added three tests covering the happy path, the get_order-failure fallback, and cancel-failure propagation.
