### PR TITLE
fix(orders): return updated order details from place_previewed_order

### DIFF
--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -1237,7 +1237,10 @@ async def place_previewed_order(
     specification (no re-derivation from parameters). Call a preview_*
     tool first to get a preview_id, review the projected order details,
     then call this tool to execute. Previews expire after 10 minutes and
-    are single-use. *Write operation.*
+    are single-use. Returns updated order details (compact/pruned, same
+    shape as get_order) after placement; falls back to a minimal
+    {orderId, accountHash, note} payload if the post-placement status fetch
+    fails or returns no data. *Write operation.*
     """
     entry = ctx.previews.pop(preview_id, account_hash)
 
@@ -1256,12 +1259,30 @@ async def place_previewed_order(
 
     decision = await run_approval(ctx, request)
     if decision is ApprovalDecision.APPROVED:
-        return await call(
+        placed = await call(
             ctx.orders.place_order,
             account_hash=account_hash,
             order_spec=entry.order_spec,
             response_handler=_order_response_handler(ctx, account_hash),
         )
+        order_id = placed.get("orderId") if isinstance(placed, dict) else None
+        if order_id is None:
+            return placed
+        order_id = str(order_id)
+        fallback: JSONType = {
+            "orderId": order_id,
+            "accountHash": account_hash,
+            "note": "Order placed; status fetch failed",
+        }
+        try:
+            result = await call(
+                ctx.orders.get_order, order_id=order_id, account_hash=account_hash
+            )
+        except (SchwabAPIError, ValueError):
+            return fallback
+        if not isinstance(result, dict):
+            return fallback
+        return _prune_order(result)
 
     message = (
         "Order placement denied by reviewer."

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -521,7 +521,90 @@ class TestPlacePreviewedOrder:
         )
 
     def test_approved_submits_cached_spec(self, monkeypatch, account_hash, order_spec):
-        """Happy path: approved decision calls place_order with the exact cached spec."""
+        """Happy path: approved decision calls place_order with the exact cached
+        spec, then fetches and returns the placed order's details."""
+        from schwab_mcp.approvals import ApprovalDecision
+        from schwab_mcp.tools import orders as orders_mod
+
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+        preview_id = self._put_entry(ctx, account_hash, order_spec)
+
+        placed_order = {
+            "orderId": 42,
+            "status": "WORKING",
+            "quantity": 100,
+            "filledQuantity": 0,
+        }
+        calls: list[dict] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append({"func": func, "kwargs": kwargs})
+            if len(calls) == 1:
+                return {"orderId": 42, "accountHash": account_hash}
+            return placed_order
+
+        async def fake_run_approval(ctx, request):
+            return ApprovalDecision.APPROVED
+
+        monkeypatch.setattr(orders_mod, "call", fake_call)
+        monkeypatch.setattr(orders_mod, "run_approval", fake_run_approval)
+
+        result = run(orders.place_previewed_order(ctx, account_hash, preview_id))
+
+        assert result == orders._prune_order(placed_order)
+        assert len(calls) == 2
+        # PreviewStore.put() deep-copies the spec (see #130), so this is an
+        # equality check rather than identity: what matters is that the
+        # exact previewed content is submitted, not re-derived from params.
+        assert calls[0]["kwargs"]["order_spec"] == order_spec
+        assert calls[0]["kwargs"]["account_hash"] == account_hash
+        # orderId from the place response is an int; the get_order call must
+        # receive it stringified since get_order's order_id param is typed str.
+        assert calls[1]["kwargs"]["order_id"] == "42"
+        assert calls[1]["kwargs"]["account_hash"] == account_hash
+
+    def test_returns_fallback_when_get_order_fails(
+        self, monkeypatch, account_hash, order_spec
+    ):
+        """If the post-placement get_order fetch fails, fall back to a minimal
+        note instead of masking the successful placement."""
+        from schwab_mcp.approvals import ApprovalDecision
+        from schwab_mcp.tools import orders as orders_mod
+        from schwab_mcp.tools.utils import SchwabAPIError
+
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+        preview_id = self._put_entry(ctx, account_hash, order_spec)
+
+        calls: list[dict] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append({"func": func, "kwargs": kwargs})
+            if len(calls) == 1:
+                return {"orderId": 42, "accountHash": account_hash}
+            raise SchwabAPIError(status_code=404, url="/order", body="not found")
+
+        async def fake_run_approval(ctx, request):
+            return ApprovalDecision.APPROVED
+
+        monkeypatch.setattr(orders_mod, "call", fake_call)
+        monkeypatch.setattr(orders_mod, "run_approval", fake_run_approval)
+
+        result = run(orders.place_previewed_order(ctx, account_hash, preview_id))
+
+        assert result == {
+            "orderId": "42",
+            "accountHash": account_hash,
+            "note": "Order placed; status fetch failed",
+        }
+
+    def test_returns_fallback_when_get_order_raises_value_error(
+        self, monkeypatch, account_hash, order_spec
+    ):
+        """If the post-placement get_order fetch raises ValueError (e.g. the
+        Schwab endpoint returned a non-JSON body), fall back to a minimal
+        note instead of letting the error mask the successful placement."""
         from schwab_mcp.approvals import ApprovalDecision
         from schwab_mcp.tools import orders as orders_mod
 
@@ -533,7 +616,9 @@ class TestPlacePreviewedOrder:
 
         async def fake_call(func, *args, **kwargs):
             calls.append({"func": func, "kwargs": kwargs})
-            return {"orderId": 42, "accountHash": account_hash}
+            if len(calls) == 1:
+                return {"orderId": 42, "accountHash": account_hash}
+            raise ValueError("Expected JSON response from Schwab endpoint")
 
         async def fake_run_approval(ctx, request):
             return ApprovalDecision.APPROVED
@@ -543,13 +628,73 @@ class TestPlacePreviewedOrder:
 
         result = run(orders.place_previewed_order(ctx, account_hash, preview_id))
 
-        assert result["orderId"] == 42
+        assert result == {
+            "orderId": "42",
+            "accountHash": account_hash,
+            "note": "Order placed; status fetch failed",
+        }
+
+    def test_returns_fallback_when_get_order_returns_no_data(
+        self, monkeypatch, account_hash, order_spec
+    ):
+        """If the post-placement get_order fetch returns no data (e.g. empty
+        body), fall back to a minimal note instead of masking the successful
+        placement."""
+        from schwab_mcp.approvals import ApprovalDecision
+        from schwab_mcp.tools import orders as orders_mod
+
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+        preview_id = self._put_entry(ctx, account_hash, order_spec)
+
+        calls: list[dict] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append({"func": func, "kwargs": kwargs})
+            if len(calls) == 1:
+                return {"orderId": 42, "accountHash": account_hash}
+            return None
+
+        async def fake_run_approval(ctx, request):
+            return ApprovalDecision.APPROVED
+
+        monkeypatch.setattr(orders_mod, "call", fake_call)
+        monkeypatch.setattr(orders_mod, "run_approval", fake_run_approval)
+
+        result = run(orders.place_previewed_order(ctx, account_hash, preview_id))
+
+        assert result == {
+            "orderId": "42",
+            "accountHash": account_hash,
+            "note": "Order placed; status fetch failed",
+        }
+
+    def test_no_order_id_skips_get_order(self, monkeypatch, account_hash, order_spec):
+        """If the place_order response has no extractable orderId (only a
+        Location header), return that payload without attempting get_order."""
+        from schwab_mcp.approvals import ApprovalDecision
+        from schwab_mcp.tools import orders as orders_mod
+
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+        preview_id = self._put_entry(ctx, account_hash, order_spec)
+
+        calls: list[dict] = []
+
+        async def fake_call(func, *args, **kwargs):
+            calls.append({"func": func, "kwargs": kwargs})
+            return {"location": "https://api.schwabapi.com/orders/123"}
+
+        async def fake_run_approval(ctx, request):
+            return ApprovalDecision.APPROVED
+
+        monkeypatch.setattr(orders_mod, "call", fake_call)
+        monkeypatch.setattr(orders_mod, "run_approval", fake_run_approval)
+
+        result = run(orders.place_previewed_order(ctx, account_hash, preview_id))
+
+        assert result == {"location": "https://api.schwabapi.com/orders/123"}
         assert len(calls) == 1
-        # PreviewStore.put() deep-copies the spec (see #130), so this is an
-        # equality check rather than identity: what matters is that the
-        # exact previewed content is submitted, not re-derived from params.
-        assert calls[0]["kwargs"]["order_spec"] == order_spec
-        assert calls[0]["kwargs"]["account_hash"] == account_hash
 
     def test_denied_raises_permission_error(
         self, monkeypatch, account_hash, order_spec
@@ -1330,6 +1475,9 @@ class DummyPreviewClient:
 
     async def place_order(self, *args: Any, **kwargs: Any) -> Any:
         self.captured = {"args": args, "kwargs": kwargs}
+        return {}
+
+    async def get_order(self, *args: Any, **kwargs: Any) -> Any:
         return {}
 
 


### PR DESCRIPTION
## What

`place_previewed_order` used to call Schwab's place endpoint and hand back whatever the response handler extracted (`orderId`/`accountHash`/`location`), which almost never includes status, quantity, or fill info. That forced the LLM caller to immediately turn around and call `get_order` just to see what actually happened, which was a wasted round trip every time. This mirrors the same fix already applied to `cancel_order` (#133).

Now `place_previewed_order` places the order, then fetches and returns the order details through the same compact/pruned path `get_order` uses, so the caller gets the real post-placement status directly.

## Details

- On successful placement, if an `orderId` was extractable from the place response, fetches the order via `get_order`'s path and returns `_prune_order(result)` — same shape callers already know from `get_order`.
- If no `orderId` could be extracted (only a `Location` header came back), returns that raw payload unchanged rather than attempting a fetch that has nothing to key on.
- If placement itself fails, or approval is denied/expired, behavior is unchanged (no follow-up fetch is attempted, exceptions propagate as before).
- If placement succeeds but the follow-up status fetch fails or returns no data, the failure is swallowed and a minimal fallback is returned instead of masking a placement that actually worked: `{"orderId", "accountHash", "note": "Order placed; status fetch failed"}`.

## Testing

`uv run pytest` (399 passed, excluding the pre-existing `test_technical_tools.py` collection error caused by an optional `pandas` dependency missing from this environment — unrelated to this change), `uv run ruff format . && uv run ruff check .` (clean), `uv run pyright` (0 errors). Added tests covering the happy path (two calls: place then get_order), the get_order-failure fallback, the get_order-empty-response fallback, and the no-orderId short-circuit.
