### PR TITLE
fix(orders): expose configurable stop-loss exit type on bracket orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ so the LLM can't hallucinate a different order than what was reviewed.
 |------|-------------|
 | `preview_equity_order` | Preview a stock/ETF buy or sell. |
 | `preview_option_order` | Preview an option contract buy or sell. |
-| `preview_bracket_order` | Preview an entry + take-profit + stop-loss order. |
+| `preview_bracket_order` | Preview an entry + take-profit + stop-loss order. Stop-loss exit type defaults to `STOP`; pass `loss_type` (`STOP`, `STOP_LIMIT`, or `LIMIT`) for a different exit, plus `loss_limit_price` when `loss_type` is `STOP_LIMIT`; the response's `resolved_leg_types` shows what was actually built. |
 | `place_previewed_order` | Place the exact order returned by a `preview_*` call, by `preview_id`. Requires approval. |
 | `cancel_order` | Cancel an open order. |
 

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -174,6 +174,7 @@ _EQUITY_ORDER_BUILDERS: dict[tuple[str, str], tuple[Any, bool, bool]] = {
 }
 
 _EQUITY_ORDER_TYPES = frozenset({"MARKET", "LIMIT", "STOP", "STOP_LIMIT"})
+_BRACKET_LOSS_TYPES = frozenset({"STOP", "STOP_LIMIT", "LIMIT"})
 _EQUITY_INSTRUCTIONS = frozenset({"BUY", "SELL"})
 
 _TRAILING_STOP_LINK_TYPES = frozenset({"VALUE", "PERCENT"})
@@ -581,6 +582,8 @@ def _prepare_bracket_order(
     duration: str | None = "DAY",
     exit_session: str | None = None,
     exit_duration: str | None = None,
+    loss_type: str = "STOP",
+    loss_limit_price: float | None = None,
 ) -> dict[str, Any]:
     if profit_price is None and loss_price is None:
         raise ValueError("At least one of profit_price or loss_price must be provided")
@@ -610,6 +613,8 @@ def _prepare_bracket_order(
         loss_price,
         eff_exit_session,
         eff_exit_duration,
+        loss_type=loss_type,
+        loss_limit_price=loss_limit_price,
     )
     return cast(dict[str, Any], bracket_builder.build())
 
@@ -827,6 +832,8 @@ def _build_bracket_exit_order(
     loss_price: float | None,
     exit_session: str | None,
     exit_duration: str | None,
+    loss_type: str = "STOP",
+    loss_limit_price: float | None = None,
 ) -> Any:
     """Build the exit leg(s) for a bracket order and assemble the
     TRIGGER > OCO/SINGLE builder around the given entry leg."""
@@ -843,9 +850,31 @@ def _build_bracket_exit_order(
         )
 
     loss_order_builder = None
-    if loss_price is not None:
+    if loss_price is None:
+        if loss_type.upper() != "STOP" or loss_limit_price is not None:
+            raise ValueError(
+                "loss_type/loss_limit_price require loss_price to be provided"
+            )
+    else:
+        loss_type = loss_type.upper()
+        if loss_type not in _BRACKET_LOSS_TYPES:
+            raise ValueError(
+                f"Invalid loss_type: {loss_type}. Must be one of: STOP, STOP_LIMIT, LIMIT"
+            )
+        if loss_type == "STOP_LIMIT" and loss_limit_price is None:
+            raise ValueError("STOP_LIMIT loss orders require loss_limit_price")
+        if loss_type != "STOP_LIMIT" and loss_limit_price is not None:
+            raise ValueError(
+                f"{loss_type} loss orders should not include loss_limit_price"
+            )
+        if loss_type == "STOP":
+            ot, p, sp = "STOP", None, loss_price
+        elif loss_type == "LIMIT":
+            ot, p, sp = "LIMIT", loss_price, None
+        else:  # STOP_LIMIT
+            ot, p, sp = "STOP_LIMIT", loss_limit_price, loss_price
         loss_order_builder = _build_equity_order_spec(
-            symbol, quantity, exit_instruction, "STOP", stop_price=loss_price
+            symbol, quantity, exit_instruction, ot, price=p, stop_price=sp
         )
         loss_order_builder = _apply_order_settings(
             loss_order_builder, exit_session, exit_duration
@@ -1113,7 +1142,20 @@ async def preview_bracket_order(
         float | None, "Take-profit limit price (optional if loss_price provided)"
     ] = None,
     loss_price: Annotated[
-        float | None, "Stop-loss trigger price (optional if profit_price provided)"
+        float | None,
+        "Stop-loss exit price (optional if profit_price provided). Trigger price "
+        "for STOP/STOP_LIMIT loss_type (default); fill price for LIMIT loss_type. "
+        "Required whenever loss_type or loss_limit_price is set.",
+    ] = None,
+    loss_type: Annotated[
+        str,
+        "Order type for the stop-loss exit leg: STOP (default), STOP_LIMIT, or LIMIT. "
+        "Requires loss_price to be set.",
+    ] = "STOP",
+    loss_limit_price: Annotated[
+        float | None,
+        "Limit fill price for the loss leg; required when loss_type is STOP_LIMIT "
+        "(and rejected otherwise). loss_price remains the stop trigger price in that case.",
     ] = None,
     entry_price: Annotated[
         float | None, "Required for LIMIT entry; Limit price for STOP_LIMIT entry"
@@ -1143,6 +1185,11 @@ async def preview_bracket_order(
     order details (validation results, commission/fees) plus a preview_id.
     Call place_previewed_order(account_hash, preview_id) to execute this
     exact order. Params: same as this order shape's fields below.
+
+    loss_price defaults to building a STOP exit order (trigger price) unless
+    loss_type overrides it to STOP_LIMIT or LIMIT, in which case loss_price is
+    the trigger/fill price respectively; loss_type and loss_limit_price require
+    loss_price to be set. profit_price always builds a LIMIT exit order.
     """
     bracket_order_dict = _prepare_bracket_order(
         symbol,
@@ -1157,6 +1204,8 @@ async def preview_bracket_order(
         duration,
         exit_session,
         exit_duration,
+        loss_type=loss_type,
+        loss_limit_price=loss_limit_price,
     )
     preview = await call(
         ctx.orders.preview_order,
@@ -1167,7 +1216,17 @@ async def preview_bracket_order(
         f"BRACKET: {entry_instruction.upper()} {quantity} {symbol} {entry_type.upper()}"
         + (f" @ ${entry_price:.2f}" if entry_price else "")
         + " + exits"
+        + (
+            f" (loss: {loss_type.upper()})"
+            if loss_price is not None and loss_type.upper() != "STOP"
+            else ""
+        )
     )
+    resolved_leg_types: dict[str, str] = {"entry": entry_type.upper()}
+    if profit_price is not None:
+        resolved_leg_types["profit"] = "LIMIT"
+    if loss_price is not None:
+        resolved_leg_types["loss"] = loss_type.upper()
     preview_id = ctx.previews.put(
         account_hash, bracket_order_dict, "preview_bracket_order", summary
     )
@@ -1175,6 +1234,7 @@ async def preview_bracket_order(
         "preview_id": preview_id,
         "preview": preview,
         "action": _preview_action(account_hash, preview_id),
+        "resolved_leg_types": resolved_leg_types,
     }
 
 

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -857,6 +857,76 @@ class TestPrepareBracketOrderValidation:
         for exit_order in oco_child["childOrderStrategies"]:
             assert exit_order["duration"] == "GOOD_TILL_CANCEL"
 
+    def test_loss_type_limit(self):
+        spec = orders._prepare_bracket_order(
+            "SPY", 100, "BUY", "MARKET", loss_price=140.0, loss_type="LIMIT"
+        )
+        child = spec["childOrderStrategies"][0]
+        assert child["orderType"] == "LIMIT"
+        assert float(child["price"]) == 140.0
+        assert "stopPrice" not in child
+
+    def test_loss_type_stop_limit(self):
+        spec = orders._prepare_bracket_order(
+            "SPY",
+            100,
+            "BUY",
+            "MARKET",
+            loss_price=140.0,
+            loss_type="STOP_LIMIT",
+            loss_limit_price=139.5,
+        )
+        child = spec["childOrderStrategies"][0]
+        assert child["orderType"] == "STOP_LIMIT"
+        assert float(child["stopPrice"]) == 140.0
+        assert float(child["price"]) == 139.5
+
+    def test_stop_limit_without_loss_limit_price_raises(self):
+        with pytest.raises(ValueError, match="loss_limit_price"):
+            orders._prepare_bracket_order(
+                "SPY",
+                100,
+                "BUY",
+                "MARKET",
+                loss_price=140.0,
+                loss_type="STOP_LIMIT",
+            )
+
+    def test_stop_with_loss_limit_price_raises(self):
+        with pytest.raises(ValueError, match="loss_limit_price"):
+            orders._prepare_bracket_order(
+                "SPY",
+                100,
+                "BUY",
+                "MARKET",
+                loss_price=140.0,
+                loss_type="STOP",
+                loss_limit_price=139.5,
+            )
+
+    def test_invalid_loss_type_raises(self):
+        with pytest.raises(ValueError, match="Invalid loss_type"):
+            orders._prepare_bracket_order(
+                "SPY", 100, "BUY", "MARKET", loss_price=140.0, loss_type="GTC"
+            )
+
+    def test_loss_type_without_loss_price_raises(self):
+        with pytest.raises(ValueError, match="loss_type/loss_limit_price"):
+            orders._prepare_bracket_order(
+                "SPY", 100, "BUY", "MARKET", profit_price=160.0, loss_type="LIMIT"
+            )
+
+    def test_loss_limit_price_without_loss_price_raises(self):
+        with pytest.raises(ValueError, match="loss_type/loss_limit_price"):
+            orders._prepare_bracket_order(
+                "SPY",
+                100,
+                "BUY",
+                "MARKET",
+                profit_price=160.0,
+                loss_limit_price=139.5,
+            )
+
 
 class TestPrepareOptionComboOrderValidation:
     def test_requires_at_least_two_legs(self):
@@ -1682,6 +1752,84 @@ class TestPreviewBracketOrder:
                     ctx, "acc123", "AAPL", 100, "BUY", "MARKET"
                 )
             )
+
+    def test_resolved_leg_types_full_bracket_default_loss(self, monkeypatch):
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+
+        async def fake_call(func, *args, **kwargs):
+            return {}
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        result = run(
+            orders.preview_bracket_order(
+                ctx,
+                "acc123",
+                "AAPL",
+                100,
+                "BUY",
+                "MARKET",
+                profit_price=160.0,
+                loss_price=140.0,
+            )
+        )
+
+        assert result["resolved_leg_types"] == {
+            "entry": "MARKET",
+            "profit": "LIMIT",
+            "loss": "STOP",
+        }
+
+    def test_resolved_leg_types_loss_limit_no_profit(self, monkeypatch):
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+
+        async def fake_call(func, *args, **kwargs):
+            return {}
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        result = run(
+            orders.preview_bracket_order(
+                ctx,
+                "acc123",
+                "AAPL",
+                100,
+                "BUY",
+                "MARKET",
+                loss_price=140.0,
+                loss_type="LIMIT",
+            )
+        )
+
+        assert result["resolved_leg_types"] == {"entry": "MARKET", "loss": "LIMIT"}
+
+    def test_resolved_leg_types_stop_limit_loss(self, monkeypatch):
+        client = DummyPreviewClient()
+        ctx = make_ctx(client)
+
+        async def fake_call(func, *args, **kwargs):
+            return {}
+
+        monkeypatch.setattr(orders, "call", fake_call)
+
+        result = run(
+            orders.preview_bracket_order(
+                ctx,
+                "acc123",
+                "AAPL",
+                100,
+                "BUY",
+                "MARKET",
+                loss_price=140.0,
+                loss_type="STOP_LIMIT",
+                loss_limit_price=139.0,
+            )
+        )
+
+        assert result["resolved_leg_types"]["loss"] == "STOP_LIMIT"
+        assert "preview_id" in result
 
 
 class TestPreviewOptionComboOrder:


### PR DESCRIPTION
## What

`preview_bracket_order`'s `loss_price` was always built as a Schwab `STOP` exit order, with no way to request a genuine `LIMIT` or `STOP_LIMIT` exit and no indication anywhere (docstring, param name, response) that this substitution was happening. `STOP` and `LIMIT` are opposite risk profiles for an exit order, so silently coercing a caller's intended limit exit into a stop changed the risk contract of the trade without their knowledge. Fixes #134.

## Details

- Added `loss_type` (`STOP` default, `STOP_LIMIT`, or `LIMIT`) and `loss_limit_price` params to `preview_bracket_order`, threaded through `_prepare_bracket_order` and `_build_bracket_exit_order`. Reuses the existing `_build_equity_order_spec` builder instead of adding new bespoke construction logic.
- `loss_price` is always the stop trigger price; `loss_limit_price` is the limit fill price, required only when `loss_type` is `STOP_LIMIT` (and rejected otherwise).
- The response now includes a top-level `resolved_leg_types` field (e.g. `{"entry": "MARKET", "profit": "LIMIT", "loss": "STOP"}`) so callers can confirm what was actually built without walking nested `childOrderStrategies`.
- Docstring now explicitly states the default `STOP` behavior for `loss_price`.
- Omitting `loss_type` reproduces the exact prior behavior — existing tests pass unchanged.
- `profit_price` intentionally stays `LIMIT`-only; take-profit as a stop order isn't a conventional pattern. `preview_trigger_order` and `preview_oco_order` already take an explicit `order_type` per leg via `OrderDesc`, so they don't have the equivalent implicit-coercion bug.

## Testing

`uv run pytest` (432 passed), `uv run ruff check .` (clean), `uv run pyright` (0 errors), `uv run vulture` (clean). Added tests for `LIMIT` and `STOP_LIMIT` loss legs, missing/superfluous `loss_limit_price` validation, invalid `loss_type`, and the `resolved_leg_types` response shape.
