### PR TITLE
fix(tools): round technical indicator output to 6 decimals

### DIFF
--- a/src/schwab_mcp/tools/technical/base.py
+++ b/src/schwab_mcp/tools/technical/base.py
@@ -362,7 +362,9 @@ def series_to_json(
         if pd.isna(timestamp) or pd.isna(value):
             continue
 
-        rows.append({"timestamp": timestamp.isoformat(), value_key: float(value)})
+        rows.append(
+            {"timestamp": timestamp.isoformat(), value_key: round(float(value), 6)}
+        )
 
     return rows
 
@@ -389,7 +391,7 @@ def frame_to_json(
     rows: list[dict[str, Any]] = []
     for timestamp, (_, row) in zip(index, numeric.iterrows()):
         valid_items = {
-            str(column): float(value)
+            str(column): round(float(value), 6)
             for column, value in row.items()
             if pd.notna(value)
         }

--- a/src/schwab_mcp/tools/technical/volatility.py
+++ b/src/schwab_mcp/tools/technical/volatility.py
@@ -261,22 +261,22 @@ async def expected_move(
     adjusted_move_percent = adjusted_move / float(underlying)
 
     boundaries = {
-        "upper_1x": float(underlying) + adjusted_move,
-        "lower_1x": float(underlying) - adjusted_move,
-        "upper_2x": float(underlying) + (adjusted_move * 2.0),
-        "lower_2x": float(underlying) - (adjusted_move * 2.0),
+        "upper_1x": _round(float(underlying) + adjusted_move, 6),
+        "lower_1x": _round(float(underlying) - adjusted_move, 6),
+        "upper_2x": _round(float(underlying) + (adjusted_move * 2.0), 6),
+        "lower_2x": _round(float(underlying) - (adjusted_move * 2.0), 6),
     }
 
     response: dict[str, JSONType] = {
         "symbol": symbol.upper(),
-        "call_price": float(call_price),
-        "put_price": float(put_price),
-        "underlying_price": float(underlying),
-        "expected_move": straddle_price,
-        "expected_move_percent": move_percent,
+        "call_price": _round(float(call_price), 6),
+        "put_price": _round(float(put_price), 6),
+        "underlying_price": _round(float(underlying), 6),
+        "expected_move": _round(straddle_price, 6),
+        "expected_move_percent": _round(move_percent, 6),
         "multiplier": float(multiplier),
-        "adjusted_move": adjusted_move,
-        "adjusted_move_percent": adjusted_move_percent,
+        "adjusted_move": _round(adjusted_move, 6),
+        "adjusted_move_percent": _round(adjusted_move_percent, 6),
         "boundaries": boundaries,
     }
 


### PR DESCRIPTION
## What

Technical indicator tools (`rsi`, `macd`, `atr`, `adx`, `moving_average`, `vwap`, `pivot_points`, `bollinger_bands`, `stoch`) return pandas/pandas-ta float64 values as-is, which JSON-serialize with 15-17 significant digits (e.g. `42.156839217492847`). That's a lot of wasted tokens for an LLM caller that never needed more than a handful of decimal places. `expected_move` had the same problem in its own hand-built response dict.

## Details

- Round values to 6 decimal places at the two shared JSON-serialization choke points in `base.py` (`series_to_json`, `frame_to_json`), which every series/frame indicator funnels through. No new parameters or per-indicator tuning — one constant applied uniformly.
- Round `expected_move()`'s previously-unrounded output fields (call/put/underlying price, expected/adjusted move, percentages, boundaries) in `volatility.py` using the existing `_round()` helper.
- `historical_volatility` already rounded its output and is untouched. Non-technical tool modules (quotes/options/history) return Schwab's own already-reasonable precision and are out of scope.
- Landed on 6 decimals rather than a tighter 4: an initial pass at 4 decimals broke several existing test assertions that compare against exact recomputed float values within `pytest.approx`'s default tolerance (e.g. `14.03125` rounding to `14.0312` exceeded the relative tolerance). 6 decimals still cuts the float64 noise roughly in half while matching every existing test's expected value exactly.

## Testing

`uv run ruff format . && uv run ruff check .` (clean), `uv run pyright` (0 errors), `uv run vulture` (clean), `uv run pytest` (438 passed). No test changes needed.
