### PR TITLE
refactor(auth): type credentials as a dataclass

### DIFF
--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -70,8 +70,8 @@ def auth(
 ) -> int:
     """Initialize Schwab client authentication."""
     creds = tokens.load_credentials(tokens.credentials_path(APP_NAME))
-    client_id = client_id or creds.get("client_id")
-    client_secret = client_secret or creds.get("client_secret")
+    client_id = client_id or creds.client_id
+    client_secret = client_secret or creds.client_secret
     if not client_id or not client_secret:
         click.echo(
             "Error: client-id and client-secret are required. "
@@ -201,8 +201,8 @@ def server(
 ) -> int:
     """Run the Schwab MCP server."""
     creds = tokens.load_credentials(tokens.credentials_path(APP_NAME))
-    client_id = client_id or creds.get("client_id")
-    client_secret = client_secret or creds.get("client_secret")
+    client_id = client_id or creds.client_id
+    client_secret = client_secret or creds.client_secret
     if not client_id or not client_secret:
         send_error_response(
             "client-id and client-secret are required. "

--- a/src/schwab_mcp/tokens.py
+++ b/src/schwab_mcp/tokens.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import pathlib
+from dataclasses import dataclass
 from typing import Any, Callable, Protocol
 
 import yaml
@@ -113,6 +114,12 @@ class Manager:
         return os.path.exists(self.path)
 
 
+@dataclass(frozen=True)
+class Credentials:
+    client_id: str | None = None
+    client_secret: str | None = None
+
+
 def credentials_path(app_name: str, filename: str = "credentials.yaml") -> str:
     """Get the path to the credentials file.
 
@@ -128,26 +135,31 @@ def credentials_path(app_name: str, filename: str = "credentials.yaml") -> str:
     return os.path.join(data_dir, filename)
 
 
-def load_credentials(path: str) -> dict[str, str]:
+def load_credentials(path: str) -> Credentials:
     """Load client credentials from a YAML file.
 
     Args:
         path: Path to the credentials file
 
     Returns:
-        Dictionary with ``client_id`` and ``client_secret`` keys, or empty
-        dict if the file does not exist.
+        Credentials with None fields if the file does not exist or is invalid.
     """
     if not os.path.exists(path):
-        return {}
+        return Credentials()
 
     with open(path) as f:
         data = yaml.safe_load(f)
 
     if not isinstance(data, dict):
-        return {}
+        return Credentials()
 
-    return data
+    client_id = data.get("client_id")
+    client_secret = data.get("client_secret")
+
+    return Credentials(
+        client_id=client_id if isinstance(client_id, str) else None,
+        client_secret=client_secret if isinstance(client_secret, str) else None,
+    )
 
 
 def save_credentials(path: str, client_id: str, client_secret: str) -> None:

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -340,10 +340,10 @@ class TestCredentialsPath:
 
 
 class TestLoadCredentials:
-    def test_returns_empty_dict_when_file_missing(self, tmp_path):
+    def test_returns_empty_credentials_when_file_missing(self, tmp_path):
         result = tokens.load_credentials(str(tmp_path / "nonexistent.yaml"))
 
-        assert result == {}
+        assert result == tokens.Credentials()
 
     def test_loads_credentials_from_yaml(self, tmp_path):
         path = str(tmp_path / "credentials.yaml")
@@ -352,25 +352,54 @@ class TestLoadCredentials:
 
         result = tokens.load_credentials(path)
 
-        assert result == {"client_id": "my-id", "client_secret": "my-secret"}
+        assert result == tokens.Credentials(
+            client_id="my-id", client_secret="my-secret"
+        )
 
-    def test_returns_empty_dict_for_non_dict_content(self, tmp_path):
+    def test_returns_empty_credentials_for_non_dict_content(self, tmp_path):
         path = str(tmp_path / "credentials.yaml")
         with open(path, "w") as f:
             f.write("just a string\n")
 
         result = tokens.load_credentials(path)
 
-        assert result == {}
+        assert result == tokens.Credentials()
 
-    def test_returns_empty_dict_for_empty_file(self, tmp_path):
+    def test_returns_empty_credentials_for_empty_file(self, tmp_path):
         path = str(tmp_path / "credentials.yaml")
         with open(path, "w") as f:
             f.write("")
 
         result = tokens.load_credentials(path)
 
-        assert result == {}
+        assert result == tokens.Credentials()
+
+    def test_ignores_unknown_keys(self, tmp_path):
+        path = str(tmp_path / "credentials.yaml")
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "client_id": "id1",
+                    "client_secret": "secret1",
+                    "extra_field": "ignored",
+                },
+                f,
+            )
+
+        result = tokens.load_credentials(path)
+
+        assert result == tokens.Credentials(client_id="id1", client_secret="secret1")
+
+    def test_coerces_non_string_values_to_none(self, tmp_path):
+        path = str(tmp_path / "credentials.yaml")
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {"client_id": 12345, "client_secret": ["not", "a", "str"]}, f
+            )
+
+        result = tokens.load_credentials(path)
+
+        assert result == tokens.Credentials()
 
 
 class TestSaveCredentials:


### PR DESCRIPTION
## What

`load_credentials()` returned a loose `dict[str, str]`, so `cli.py` had to pull fields out with `.get("client_id")` / `.get("client_secret")` with no static guarantee the returned shape actually had those keys, and no protection against a credentials file with only one of the two fields or with unrelated garbage keys mixed in.

This replaces that with a frozen `Credentials` dataclass (`client_id: str | None`, `client_secret: str | None`). `load_credentials()` always returns a `Credentials` instance now (never a bare dict), so the two `cli.py` call sites become plain attribute access (`creds.client_id`) instead of dict lookups. Unknown keys in `credentials.yaml` are now silently dropped rather than passed through, which is fine since nothing ever read them.

The OAuth token dict handled separately by `Manager`/`token_writer`/`token_loader` is intentionally left untouched — its schema is owned by `schwab-py`/authlib as an opaque passthrough (arbitrary extra keys are round-tripped on purpose, see the existing `test_preserves_nested_structures` / `test_ignores_extra_arguments` tests), so it stays a plain dict.

## Testing

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run vulture`
- `uv run pytest` (439 passed)

Added a new `test_ignores_unknown_keys` case and renamed the existing empty-dict assertions in `TestLoadCredentials` to assert against `Credentials()` / `Credentials(client_id=..., client_secret=...)` instead of raw dicts.
