### PR TITLE
refactor(tools): type OrderDesc as a dataclass

### DIFF
--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -2,6 +2,7 @@
 
 import uuid
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Annotated, Any, cast
 
 from typing_extensions import TypedDict
@@ -247,12 +248,10 @@ def _build_trailing_stop_from_desc(
     ValueErrors as the inline branch it replaces."""
     if asset_type == "OPTION":
         raise ValueError("TRAILING_STOP orders are not supported for OPTION asset_type")
-    trail_offset = desc.get("trail_offset")
-    if trail_offset is None:
+    if desc.trail_offset is None:
         raise ValueError("TRAILING_STOP orders require 'trail_offset'")
-    trail_type = desc.get("trail_type", "VALUE")
     return _build_trailing_stop_order_spec(
-        symbol, quantity, instruction, trail_offset, trail_type
+        symbol, quantity, instruction, desc.trail_offset, desc.trail_type
     )
 
 
@@ -323,8 +322,8 @@ def _build_option_order_spec(
         return limit_builder(symbol, quantity, price)
 
 
-class _OrderDescRequired(TypedDict):
-    """Required fields for an order leg description."""
+class _OrderDescInputRequired(TypedDict):
+    """Required fields for an order leg description (TypedDict for MCP schema)."""
 
     symbol: str
     quantity: int
@@ -332,16 +331,13 @@ class _OrderDescRequired(TypedDict):
     order_type: str
 
 
-class OrderDesc(_OrderDescRequired, total=False):
-    """Description of a single order leg for composite order tools.
+class _OrderDescInput(_OrderDescInputRequired, total=False):
+    """TypedDict used as the MCP tool parameter type for order leg dicts.
 
-    Required fields: symbol, quantity, instruction, order_type.
-    Conditional fields depend on order_type:
-      - price: required for LIMIT and STOP_LIMIT (equity/option)
-      - stop_price: required for STOP and STOP_LIMIT (equity only)
-      - trail_offset: required for TRAILING_STOP
-      - trail_type: VALUE (default) or PERCENT for TRAILING_STOP
-    Optional overrides: asset_type (EQUITY default), session, duration.
+    FastMCP generates the JSON schema for tool inputs from this TypedDict.
+    Raw dicts received from MCP clients are validated and converted to
+    ``OrderDesc`` dataclass instances via ``OrderDesc.from_dict()`` before
+    any internal processing occurs.
     """
 
     price: float
@@ -353,91 +349,147 @@ class OrderDesc(_OrderDescRequired, total=False):
     duration: str
 
 
-def _validate_order_desc_fields(desc: OrderDesc) -> tuple[str, int, str, str, str]:
-    """Validate and extract the required OrderDesc fields, raising ValueError with
-    a descriptive message if required fields are missing or values are invalid.
+@dataclass(frozen=True)
+class OrderDesc:
+    """Description of a single order leg for composite order tools.
 
-    Since OrderDesc dicts typically originate from untrusted MCP tool-call JSON
-    (not Python literals), required keys are checked explicitly at runtime
-    rather than relying on static typing.
+    Instances are created via ``OrderDesc.from_dict(raw)`` which validates
+    and normalises the raw dict received from untrusted MCP tool-call JSON.
+
+    Required fields: symbol, quantity, instruction, order_type.
+    Conditional fields depend on order_type:
+      - price: required for LIMIT and STOP_LIMIT (equity/option)
+      - stop_price: required for STOP and STOP_LIMIT (equity only)
+      - trail_offset: required for TRAILING_STOP (validated lazily at build time)
+      - trail_type: VALUE (default) or PERCENT for TRAILING_STOP
+    Optional overrides: asset_type (EQUITY default), session, duration.
     """
-    required = ("symbol", "quantity", "instruction", "order_type")
-    missing = [field for field in required if field not in desc]
-    if missing:
-        raise ValueError(f"missing required field(s): {', '.join(missing)}")
 
-    for field in ("symbol", "instruction", "order_type"):
-        value = desc[field]
-        if not isinstance(value, str):
-            raise ValueError(f"{field} must be a string, got {value!r}")
+    symbol: str
+    quantity: int
+    instruction: str
+    order_type: str
+    price: float | None = None
+    stop_price: float | None = None
+    trail_offset: float | None = None
+    trail_type: str = "VALUE"
+    asset_type: str = "EQUITY"
+    session: str | None = None
+    duration: str | None = None
 
-    quantity = desc["quantity"]
-    if not isinstance(quantity, int) or isinstance(quantity, bool):
-        raise ValueError(f"quantity must be an integer, got {quantity!r}")
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "OrderDesc":
+        """Validate and construct an ``OrderDesc`` from a raw dict.
 
-    symbol = desc["symbol"]
-    instruction = desc["instruction"]
-    order_type = desc["order_type"].upper()
-    asset_type = _validate_order_desc_asset_type(desc.get("asset_type", "EQUITY"))
+        Performs all field-presence and type checks (including optional
+        fields, when present), normalises ``order_type`` and ``asset_type``
+        to uppercase, and raises ``ValueError`` with a descriptive message on
+        any validation failure.
 
-    return symbol, quantity, instruction, order_type, asset_type
+        Requiredness of conditional fields (e.g. ``price`` for LIMIT orders,
+        ``trail_offset`` for TRAILING_STOP orders) is intentionally left to
+        the order builders, which know which fields apply for a given
+        ``order_type``/``asset_type`` combination. This method only checks
+        that fields, when present, have the right type.
+        """
+        required = ("symbol", "quantity", "instruction", "order_type")
+        missing = [field for field in required if field not in raw]
+        if missing:
+            raise ValueError(f"missing required field(s): {', '.join(missing)}")
 
+        for field in ("symbol", "instruction", "order_type"):
+            value = raw[field]
+            if not isinstance(value, str):
+                raise ValueError(f"{field} must be a string, got {value!r}")
 
-def _validate_order_desc_asset_type(raw_asset_type: Any) -> str:
-    """Validate and normalize the OrderDesc asset_type field."""
-    if not isinstance(raw_asset_type, str):
-        raise ValueError(f"asset_type must be a string, got {raw_asset_type!r}")
-    asset_type = raw_asset_type.upper()
-    if asset_type not in ("EQUITY", "OPTION"):
-        raise ValueError(f"Invalid asset_type: {asset_type}. Must be EQUITY or OPTION.")
-    return asset_type
+        quantity = raw["quantity"]
+        if not isinstance(quantity, int) or isinstance(quantity, bool):
+            raise ValueError(f"quantity must be an integer, got {quantity!r}")
+
+        raw_asset_type = raw.get("asset_type", "EQUITY")
+        if not isinstance(raw_asset_type, str):
+            raise ValueError(f"asset_type must be a string, got {raw_asset_type!r}")
+        asset_type = raw_asset_type.upper()
+        if asset_type not in ("EQUITY", "OPTION"):
+            raise ValueError(
+                f"Invalid asset_type: {asset_type}. Must be EQUITY or OPTION."
+            )
+
+        for field in ("price", "stop_price", "trail_offset"):
+            value = raw.get(field)
+            if value is not None and (
+                not isinstance(value, (int, float)) or isinstance(value, bool)
+            ):
+                raise ValueError(f"{field} must be a number, got {value!r}")
+
+        trail_type = raw.get("trail_type", "VALUE")
+        if not isinstance(trail_type, str):
+            raise ValueError(f"trail_type must be a string, got {trail_type!r}")
+
+        for field in ("session", "duration"):
+            value = raw.get(field)
+            if value is not None and not isinstance(value, str):
+                raise ValueError(f"{field} must be a string, got {value!r}")
+
+        return cls(
+            symbol=raw["symbol"],
+            quantity=quantity,
+            instruction=raw["instruction"],
+            order_type=raw["order_type"].upper(),
+            price=raw.get("price"),
+            stop_price=raw.get("stop_price"),
+            trail_offset=raw.get("trail_offset"),
+            trail_type=trail_type,
+            asset_type=asset_type,
+            session=raw.get("session"),
+            duration=raw.get("duration"),
+        )
 
 
 def _build_order_from_desc(
-    desc: OrderDesc,
+    desc: dict[str, Any],
     default_session: str | None,
     default_duration: str | None,
 ) -> Any:
-    """Build an OrderBuilder from an OrderDesc dict.
+    """Build an OrderBuilder from a raw order-leg dict.
 
-    Routes to the appropriate internal builder based on asset_type and
-    order_type. Per-leg session/duration in the OrderDesc override the
-    provided defaults when present.
+    Validates and converts ``desc`` to an ``OrderDesc`` dataclass via
+    ``OrderDesc.from_dict()``, then routes to the appropriate internal
+    builder based on asset_type and order_type. Per-leg session/duration
+    in the dict override the provided defaults when present.
 
     Raises ValueError with a descriptive message if required fields are
-    missing or values are invalid. Since OrderDesc dicts typically originate
+    missing or values are invalid. Since order-leg dicts typically originate
     from untrusted MCP tool-call JSON (not Python literals), required keys
     are checked explicitly at runtime rather than relying on static typing.
     """
-    symbol, quantity, instruction, order_type, asset_type = _validate_order_desc_fields(
-        desc
-    )
+    od = OrderDesc.from_dict(desc)
 
     # Determine effective session/duration (per-leg overrides defaults)
-    session = desc.get("session", default_session)
-    duration = desc.get("duration", default_duration)
+    session = od.session if od.session is not None else default_session
+    duration = od.duration if od.duration is not None else default_duration
 
-    if order_type == "TRAILING_STOP":
+    if od.order_type == "TRAILING_STOP":
         builder = _build_trailing_stop_from_desc(
-            desc, symbol, quantity, instruction, asset_type
+            od, od.symbol, od.quantity, od.instruction, od.asset_type
         )
-    elif asset_type == "OPTION":
+    elif od.asset_type == "OPTION":
         builder = _build_option_order_spec(
-            symbol,
-            quantity,
-            instruction,
-            order_type,
-            price=desc.get("price"),
+            od.symbol,
+            od.quantity,
+            od.instruction,
+            od.order_type,
+            price=od.price,
         )
     else:
         # Default: EQUITY
         builder = _build_equity_order_spec(
-            symbol,
-            quantity,
-            instruction,
-            order_type,
-            price=desc.get("price"),
-            stop_price=desc.get("stop_price"),
+            od.symbol,
+            od.quantity,
+            od.instruction,
+            od.order_type,
+            price=od.price,
+            stop_price=od.stop_price,
         )
 
     builder = _apply_order_settings(builder, session, duration)
@@ -526,8 +578,8 @@ def _prepare_trailing_stop_order(
 
 
 def _prepare_oco_order(
-    first_order: "OrderDesc",
-    second_order: "OrderDesc",
+    first_order: dict[str, Any],
+    second_order: dict[str, Any],
     session: str | None = "NORMAL",
     duration: str | None = "DAY",
 ) -> dict[str, Any]:
@@ -544,8 +596,8 @@ def _prepare_oco_order(
 
 
 def _prepare_trigger_order(
-    entry_order: "OrderDesc",
-    exit_orders: "list[OrderDesc]",
+    entry_order: dict[str, Any],
+    exit_orders: list[dict[str, Any]],
     session: str | None = "NORMAL",
     duration: str | None = "DAY",
 ) -> dict[str, Any]:
@@ -1037,13 +1089,13 @@ async def preview_oco_order(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
     first_order: Annotated[
-        OrderDesc,
+        _OrderDescInput,
         "First order leg description. Required fields: symbol, quantity, instruction, order_type. "
         "Conditional: price (LIMIT/STOP_LIMIT), stop_price (STOP/STOP_LIMIT), "
         "trail_offset (TRAILING_STOP). Optional: asset_type (EQUITY/OPTION), session, duration.",
     ],
     second_order: Annotated[
-        OrderDesc,
+        _OrderDescInput,
         "Second order leg description. Same fields as first_order. "
         "Execution of one cancels the other.",
     ],
@@ -1062,7 +1114,12 @@ async def preview_oco_order(
     Call place_previewed_order(account_hash, preview_id) to execute this
     exact order. Params: same as this order shape's fields below.
     """
-    order_spec_dict = _prepare_oco_order(first_order, second_order, session, duration)
+    order_spec_dict = _prepare_oco_order(
+        cast(dict[str, Any], first_order),
+        cast(dict[str, Any], second_order),
+        session,
+        duration,
+    )
     preview = await call(
         ctx.orders.preview_order, account_hash=account_hash, order_spec=order_spec_dict
     )
@@ -1084,13 +1141,13 @@ async def preview_trigger_order(
     ctx: SchwabContext,
     account_hash: Annotated[str, "Account hash for the Schwab account"],
     entry_order: Annotated[
-        OrderDesc,
+        _OrderDescInput,
         "Entry (primary) order description. Required fields: symbol, quantity, instruction, order_type. "
         "Conditional: price (LIMIT/STOP_LIMIT), stop_price (STOP/STOP_LIMIT), "
         "trail_offset (TRAILING_STOP). Optional: asset_type (EQUITY/OPTION), session, duration.",
     ],
     exit_orders: Annotated[
-        list[OrderDesc],
+        list[_OrderDescInput],
         "Exit order(s) triggered after entry fills. "
         "1 exit: simple trigger(entry, exit). "
         "2 exits: trigger(entry, oco(exit1, exit2)) — full bracket-like structure. "
@@ -1112,7 +1169,10 @@ async def preview_trigger_order(
     exact order. Params: same as this order shape's fields below.
     """
     order_spec_dict = _prepare_trigger_order(
-        entry_order, exit_orders, session, duration
+        cast(dict[str, Any], entry_order),
+        cast(list[dict[str, Any]], exit_orders),
+        session,
+        duration,
     )
     preview = await call(
         ctx.orders.preview_order, account_hash=account_hash, order_spec=order_spec_dict

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -868,14 +868,14 @@ class TestPrepareTrailingStopOrderValidation:
 
 
 class TestPrepareOcoOrderValidation:
-    _GOOD_FIRST: orders.OrderDesc = {
+    _GOOD_FIRST: dict[str, Any] = {
         "symbol": "SPY",
         "quantity": 100,
         "instruction": "SELL",
         "order_type": "LIMIT",
         "price": 160.0,
     }
-    _GOOD_SECOND: orders.OrderDesc = {
+    _GOOD_SECOND: dict[str, Any] = {
         "symbol": "SPY",
         "quantity": 100,
         "instruction": "SELL",
@@ -884,7 +884,7 @@ class TestPrepareOcoOrderValidation:
     }
 
     def test_invalid_first_order_raises_with_prefix(self):
-        bad_first: orders.OrderDesc = {
+        bad_first: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 100,
             "instruction": "SELL",
@@ -894,7 +894,7 @@ class TestPrepareOcoOrderValidation:
             orders._prepare_oco_order(bad_first, self._GOOD_SECOND)
 
     def test_invalid_second_order_raises_with_prefix(self):
-        bad_second: orders.OrderDesc = {
+        bad_second: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 100,
             "instruction": "SELL",
@@ -910,7 +910,7 @@ class TestPrepareOcoOrderValidation:
 
 
 class TestPrepareTriggerOrderValidation:
-    _ENTRY: orders.OrderDesc = {
+    _ENTRY: dict[str, Any] = {
         "symbol": "SPY",
         "quantity": 100,
         "instruction": "BUY",
@@ -922,13 +922,13 @@ class TestPrepareTriggerOrderValidation:
             orders._prepare_trigger_order(self._ENTRY, [])
 
     def test_invalid_entry_raises_with_prefix(self):
-        bad_entry: orders.OrderDesc = {
+        bad_entry: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 10,
             "instruction": "BUY",
             "order_type": "LIMIT",
         }
-        exit_order: orders.OrderDesc = {
+        exit_order: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 10,
             "instruction": "SELL",
@@ -938,7 +938,7 @@ class TestPrepareTriggerOrderValidation:
             orders._prepare_trigger_order(bad_entry, [exit_order])
 
     def test_invalid_exit_raises_with_index_prefix(self):
-        bad_exit: orders.OrderDesc = {
+        bad_exit: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 10,
             "instruction": "SELL",
@@ -1096,7 +1096,7 @@ class TestBuildOrderFromDesc:
     """Tests for the _build_order_from_desc dispatcher."""
 
     def test_equity_market_order(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 10,
             "instruction": "BUY",
@@ -1109,7 +1109,7 @@ class TestBuildOrderFromDesc:
         assert spec["orderLegCollection"][0]["instrument"]["symbol"] == "AAPL"
 
     def test_equity_limit_order(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "SPY",
             "quantity": 5,
             "instruction": "SELL",
@@ -1122,7 +1122,7 @@ class TestBuildOrderFromDesc:
         assert float(spec["price"]) == 450.00
 
     def test_equity_stop_order(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "TSLA",
             "quantity": 2,
             "instruction": "SELL",
@@ -1135,7 +1135,7 @@ class TestBuildOrderFromDesc:
         assert float(spec["stopPrice"]) == 200.00
 
     def test_equity_stop_limit_order(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "NVDA",
             "quantity": 3,
             "instruction": "BUY",
@@ -1150,7 +1150,7 @@ class TestBuildOrderFromDesc:
         assert float(spec["stopPrice"]) == 795.00
 
     def test_option_buy_to_open_market(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "SPY 251219C500",
             "quantity": 1,
             "instruction": "BUY_TO_OPEN",
@@ -1163,7 +1163,7 @@ class TestBuildOrderFromDesc:
         assert spec["orderLegCollection"][0]["instruction"] == "BUY_TO_OPEN"
 
     def test_option_sell_to_close_limit(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "SPY 251219C500",
             "quantity": 2,
             "instruction": "SELL_TO_CLOSE",
@@ -1178,7 +1178,7 @@ class TestBuildOrderFromDesc:
         assert spec["orderLegCollection"][0]["instruction"] == "SELL_TO_CLOSE"
 
     def test_trailing_stop_value(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 10,
             "instruction": "SELL",
@@ -1193,7 +1193,7 @@ class TestBuildOrderFromDesc:
         assert spec["stopPriceLinkType"] == "VALUE"
 
     def test_trailing_stop_percent(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "TSLA",
             "quantity": 5,
             "instruction": "SELL",
@@ -1206,20 +1206,57 @@ class TestBuildOrderFromDesc:
         assert spec["stopPriceLinkType"] == "PERCENT"
 
     def test_missing_required_field_raises(self):
-        # OrderDesc dicts arrive as untrusted MCP tool-call JSON, not Python
-        # literals, so required keys are checked explicitly at runtime and
-        # raise a descriptive ValueError rather than a bare KeyError.
+        # Order-leg dicts arrive as untrusted MCP tool-call JSON, not Python
+        # literals, so required keys are checked explicitly at runtime (via
+        # OrderDesc.from_dict()) and raise a descriptive ValueError rather
+        # than a bare KeyError.
         bad_desc = {"symbol": "AAPL", "quantity": 10, "instruction": "BUY"}
         with pytest.raises(ValueError, match="order_type"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_missing_multiple_required_fields_raises(self):
         bad_desc = {"symbol": "AAPL"}
         with pytest.raises(ValueError, match="quantity.*instruction.*order_type"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
+
+    @pytest.mark.parametrize("field", ["price", "stop_price", "trail_offset"])
+    def test_non_numeric_optional_field_raises(self, field):
+        bad_desc = {
+            "symbol": "AAPL",
+            "quantity": 10,
+            "instruction": "BUY",
+            "order_type": "LIMIT",
+            field: "not-a-number",
+        }
+        with pytest.raises(ValueError, match=f"{field} must be a number"):
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
+
+    def test_non_string_trail_type_raises(self):
+        bad_desc = {
+            "symbol": "AAPL",
+            "quantity": 10,
+            "instruction": "SELL",
+            "order_type": "TRAILING_STOP",
+            "trail_offset": 1.0,
+            "trail_type": 123,
+        }
+        with pytest.raises(ValueError, match="trail_type must be a string"):
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
+
+    @pytest.mark.parametrize("field", ["session", "duration"])
+    def test_non_string_session_or_duration_raises(self, field):
+        bad_desc = {
+            "symbol": "AAPL",
+            "quantity": 10,
+            "instruction": "BUY",
+            "order_type": "MARKET",
+            field: 123,
+        }
+        with pytest.raises(ValueError, match=f"{field} must be a string"):
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_trailing_stop_with_option_raises(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "SPY 251219C500",
             "quantity": 1,
             "instruction": "SELL_TO_CLOSE",
@@ -1231,7 +1268,7 @@ class TestBuildOrderFromDesc:
             orders._build_order_from_desc(desc, "NORMAL", "DAY")
 
     def test_per_leg_session_overrides_default(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 10,
             "instruction": "BUY",
@@ -1243,7 +1280,7 @@ class TestBuildOrderFromDesc:
         assert spec["session"] == "AM"
 
     def test_per_leg_duration_overrides_default(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 10,
             "instruction": "BUY",
@@ -1255,7 +1292,7 @@ class TestBuildOrderFromDesc:
         assert spec["duration"] == "GOOD_TILL_CANCEL"
 
     def test_trailing_stop_missing_trail_offset_raises(self):
-        desc: orders.OrderDesc = {
+        desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 5,
             "instruction": "SELL",
@@ -1277,7 +1314,7 @@ class TestBuildOrderFromDesc:
             "order_type": None,
         }
         with pytest.raises(ValueError, match="order_type must be a string"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_non_string_asset_type_raises_value_error(self):
         bad_desc = {
@@ -1288,10 +1325,10 @@ class TestBuildOrderFromDesc:
             "asset_type": 123,
         }
         with pytest.raises(ValueError, match="asset_type must be a string"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_invalid_asset_type_raises_value_error(self):
-        bad_desc: orders.OrderDesc = {
+        bad_desc: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 10,
             "instruction": "BUY",
@@ -1309,7 +1346,7 @@ class TestBuildOrderFromDesc:
             "order_type": "MARKET",
         }
         with pytest.raises(ValueError, match="symbol must be a string"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_non_int_quantity_raises_value_error(self):
         bad_desc = {
@@ -1319,7 +1356,7 @@ class TestBuildOrderFromDesc:
             "order_type": "MARKET",
         }
         with pytest.raises(ValueError, match="quantity must be an integer"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_bool_quantity_raises_value_error(self):
         # bool is a subclass of int in Python; reject it explicitly so a
@@ -1331,7 +1368,7 @@ class TestBuildOrderFromDesc:
             "order_type": "MARKET",
         }
         with pytest.raises(ValueError, match="quantity must be an integer"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
     def test_non_string_instruction_raises_value_error(self):
         bad_desc = {
@@ -1341,7 +1378,7 @@ class TestBuildOrderFromDesc:
             "order_type": "MARKET",
         }
         with pytest.raises(ValueError, match="instruction must be a string"):
-            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")  # type: ignore[arg-type]
+            orders._build_order_from_desc(bad_desc, "NORMAL", "DAY")
 
 
 class TestCreateOptionSymbol:
@@ -1722,14 +1759,14 @@ class TestPreviewEquityTrailingStopOrder:
 
 
 class TestPreviewOcoOrder:
-    _LIMIT_LEG: orders.OrderDesc = {
+    _LIMIT_LEG: dict[str, Any] = {
         "symbol": "AAPL",
         "quantity": 100,
         "instruction": "SELL",
         "order_type": "LIMIT",
         "price": 160.0,
     }
-    _STOP_LEG: orders.OrderDesc = {
+    _STOP_LEG: dict[str, Any] = {
         "symbol": "AAPL",
         "quantity": 100,
         "instruction": "SELL",
@@ -1747,7 +1784,7 @@ class TestPreviewOcoOrder:
         monkeypatch.setattr(orders, "call", fake_call)
 
         result = run(
-            orders.preview_oco_order(ctx, "acc123", self._LIMIT_LEG, self._STOP_LEG)
+            orders.preview_oco_order(ctx, "acc123", self._LIMIT_LEG, self._STOP_LEG)  # type: ignore[arg-type]
         )
 
         assert "preview_id" in result
@@ -1763,7 +1800,7 @@ class TestPreviewOcoOrder:
         monkeypatch.setattr(orders, "call", fake_call)
 
         result = run(
-            orders.preview_oco_order(ctx, "acc123", self._LIMIT_LEG, self._STOP_LEG)
+            orders.preview_oco_order(ctx, "acc123", self._LIMIT_LEG, self._STOP_LEG)  # type: ignore[arg-type]
         )
 
         entry = ctx.previews.pop(result["preview_id"], "acc123")
@@ -1774,7 +1811,7 @@ class TestPreviewOcoOrder:
 class TestPreviewTriggerOrder:
     def _make_leg(
         self, instruction: str = "BUY", order_type: str = "MARKET"
-    ) -> orders.OrderDesc:
+    ) -> dict[str, Any]:
         return {
             "symbol": "AAPL",
             "quantity": 100,
@@ -1791,7 +1828,7 @@ class TestPreviewTriggerOrder:
 
         monkeypatch.setattr(orders, "call", fake_call)
 
-        exit_leg: orders.OrderDesc = {
+        exit_leg: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 100,
             "instruction": "SELL",
@@ -1799,7 +1836,7 @@ class TestPreviewTriggerOrder:
             "price": 160.0,
         }
         result = run(
-            orders.preview_trigger_order(ctx, "acc123", self._make_leg(), [exit_leg])
+            orders.preview_trigger_order(ctx, "acc123", self._make_leg(), [exit_leg])  # type: ignore[arg-type]
         )
 
         assert "preview_id" in result
@@ -1814,7 +1851,7 @@ class TestPreviewTriggerOrder:
 
         monkeypatch.setattr(orders, "call", fake_call)
 
-        exit_leg: orders.OrderDesc = {
+        exit_leg: dict[str, Any] = {
             "symbol": "AAPL",
             "quantity": 100,
             "instruction": "SELL",
@@ -1822,7 +1859,7 @@ class TestPreviewTriggerOrder:
             "price": 160.0,
         }
         result = run(
-            orders.preview_trigger_order(ctx, "acc123", self._make_leg(), [exit_leg])
+            orders.preview_trigger_order(ctx, "acc123", self._make_leg(), [exit_leg])  # type: ignore[arg-type]
         )
 
         entry = ctx.previews.pop(result["preview_id"], "acc123")
@@ -1833,7 +1870,7 @@ class TestPreviewTriggerOrder:
         client = DummyPreviewClient()
         ctx = make_ctx(client)
         with pytest.raises(ValueError, match="exit_orders must contain"):
-            run(orders.preview_trigger_order(ctx, "acc123", self._make_leg(), []))
+            run(orders.preview_trigger_order(ctx, "acc123", self._make_leg(), []))  # type: ignore[arg-type]
 
 
 class TestPreviewBracketOrder:


### PR DESCRIPTION
## What

`OrderDesc` was a `TypedDict`, so the internal order-building code had to pull fields out with `.get("session", default_session)` / `.get("price")` / `.get("trail_offset")` scattered across three different builder functions, with no single place enforcing what a valid order leg actually looks like. Required-field and type validation lived in a separate `_validate_order_desc_fields()` / `_validate_order_desc_asset_type()` pair that callers had to remember to invoke first.

This replaces the internal representation with a frozen `OrderDesc` dataclass plus an `OrderDesc.from_dict()` classmethod that does all the validation (required fields, type checks, `order_type`/`asset_type` normalization) once, in one place. `_build_order_from_desc` and `_build_trailing_stop_from_desc` now read plain attributes (`od.price`, `od.session`, `desc.trail_offset`) instead of defending against missing keys at every call site. Same pattern as #138's `Credentials` dataclass.

The public MCP tool surface is unchanged: `preview_oco_order` / `preview_trigger_order` still accept a `TypedDict` (renamed `_OrderDescInput`) for their `first_order`/`second_order`/`entry_order`/`exit_orders` parameters, since FastMCP generates the tool's JSON schema from that type — swapping it for a dataclass there would change (or break) the schema clients see. Raw dicts from MCP clients get converted to `OrderDesc` internally via `from_dict()`.

`trail_offset` validation stays lazy and unchanged — it's only required for `TRAILING_STOP` orders, so it's still checked in `_build_trailing_stop_from_desc` rather than in `from_dict()`.

## Testing

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run pyright`
- `uv run vulture`
- `uv run pytest` (440 passed)

Updated `tests/test_orders.py` call sites that previously constructed `orders.OrderDesc` dict literals to use plain `dict[str, Any]` instead, since the raw-dict boundary is now at `OrderDesc.from_dict()`/the public tool functions rather than the type alias itself.
