### PR TITLE
test: raise coverage on auth, discord approvals, and technical indicators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ addopts = "--cov=schwab_mcp --cov-report=term-missing"
 [tool.coverage.run]
 source = ["src/schwab_mcp"]
 branch = true
-omit = ["*/tests/*"]
+omit = ["*/tests/*", "*/tools/_protocols.py"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/tests/test_approval_wrapping.py
+++ b/tests/test_approval_wrapping.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, Awaitable, TypeVar, cast
 
@@ -177,3 +178,114 @@ def test_discord_manager_requires_approvers() -> None:
     )
     with pytest.raises(ValueError):
         DiscordApprovalManager(settings)
+
+
+# ---------------------------------------------------------------------------
+# _wrap_with_approval: missing context-param guard
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_with_approval_raises_when_no_context_param() -> None:
+    """Tools without a SchwabContext parameter are rejected at wrap time."""
+
+    async def no_ctx_tool(symbol: str) -> str:
+        return symbol
+
+    with pytest.raises(TypeError, match="must accept a SchwabContext parameter"):
+        _registration._wrap_with_approval(no_ctx_tool)
+
+
+# ---------------------------------------------------------------------------
+# _wrap_with_approval: context not supplied at call time
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_with_approval_raises_when_context_not_provided() -> None:
+    """Calling a wrapped tool without passing the context raises RuntimeError."""
+
+    async def tool_with_ctx(ctx: SchwabContext, value: str) -> str:
+        return value
+
+    wrapped = _registration._wrap_with_approval(tool_with_ctx)
+
+    async def runner() -> None:
+        # Use bind_partial semantics: omit ctx entirely so it's not in bound.arguments.
+        await wrapped(value="hello")  # type: ignore[call-arg]
+
+    with pytest.raises(RuntimeError, match="missing SchwabContext"):
+        asyncio.run(runner())
+
+
+# ---------------------------------------------------------------------------
+# _wrap_with_approval: sync (non-awaitable) result after approval
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_with_approval_handles_sync_result() -> None:
+    """A tool that returns synchronously (not awaitable) still works after approval."""
+
+    def sync_tool(ctx: SchwabContext, value: str) -> str:  # type: ignore[return-value]
+        return value.upper()
+
+    wrapped = _registration._wrap_with_approval(sync_tool)  # type: ignore[arg-type]
+    ctx, _, _, _ = make_ctx(ApprovalDecision.APPROVED)
+
+    result = await_result(wrapped(ctx, "spy"))
+    assert result == "SPY"
+
+
+# ---------------------------------------------------------------------------
+# _start_approval_keepalive: task runs iterations then cancels cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_keepalive_task_sends_progress_and_cancels_cleanly(monkeypatch) -> None:
+    """The keepalive task emits progress pings and exits on cancellation."""
+    ctx, _, session, _ = make_ctx(
+        ApprovalDecision.APPROVED, progress_token="tok-keepalive"
+    )
+    monkeypatch.setattr(_registration, "_APPROVAL_PROGRESS_INTERVAL", 0.001)
+
+    async def runner() -> None:
+        task = _registration._start_approval_keepalive(ctx)
+        assert task is not None
+        # Let the keepalive fire at least once.
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        # At least one keepalive progress notification should have been emitted.
+        keepalive_msgs = [
+            p for p in session.progress if "elapsed" in (p.get("message") or "")
+        ]
+        assert len(keepalive_msgs) >= 1
+
+    asyncio.run(runner())
+
+
+def test_keepalive_not_started_without_progress_token() -> None:
+    """No keepalive task is created when the context has no progress token."""
+    ctx, _, _, _ = make_ctx(ApprovalDecision.APPROVED)  # no progress_token
+
+    async def runner() -> None:
+        task = _registration._start_approval_keepalive(ctx)
+        assert task is None
+
+    asyncio.run(runner())
+
+
+# ---------------------------------------------------------------------------
+# _has_progress_token: ValueError from request_context property
+# ---------------------------------------------------------------------------
+
+
+def test_has_progress_token_returns_false_on_value_error() -> None:
+    """_has_progress_token returns False when request_context raises ValueError."""
+
+    class _BadContext:
+        @property
+        def request_context(self) -> Any:
+            raise ValueError("not in a request")
+
+    bad_ctx = cast(SchwabContext, _BadContext())
+    assert _registration._has_progress_token(bad_ctx) is False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,435 @@
+"""Unit tests for schwab_mcp/auth.py."""
+
+from __future__ import annotations
+
+import queue
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx as _httpx
+import pytest
+from schwab import auth as schwab_auth
+
+from schwab_mcp import auth as mcp_auth
+from schwab_mcp import tokens
+
+# ---------------------------------------------------------------------------
+# Helpers / stubs
+# ---------------------------------------------------------------------------
+
+FAKE_CLIENT_ID = "test-client-id"
+FAKE_CLIENT_SECRET = "test-client-secret"
+VALID_CALLBACK_URL = "https://127.0.0.1:8182"
+
+
+class DummyClient:
+    """Minimal stand-in for AsyncClient / Client."""
+
+    def __init__(self, token_age: float = 0.0):
+        self._token_age = token_age
+
+    def token_age(self) -> float:
+        return self._token_age
+
+
+class DummyTokenManager(tokens.Manager):
+    """Minimal stand-in for tokens.Manager that avoids touching the filesystem."""
+
+    def __init__(self, *, exists: bool = True, path: str = "/tmp/token.yaml"):
+        # Bypass tokens.Manager.__init__ to avoid token_loader/token_writer calls
+        self.path = path
+        self.load = MagicMock()  # type: ignore[assignment]
+        self.write = MagicMock()  # type: ignore[assignment]
+        self._exists_flag = exists
+
+    def exists(self) -> bool:
+        return self._exists_flag
+
+
+class DummyAuthContext:
+    authorization_url = "https://auth.schwab.com/oauth2/authorize?client_id=x"
+
+
+# ---------------------------------------------------------------------------
+# easy_client tests
+# ---------------------------------------------------------------------------
+
+
+def _make_dummy_client(token_age: float = 0.0) -> DummyClient:
+    return DummyClient(token_age=token_age)
+
+
+@patch("schwab_mcp.auth.client_from_login_flow")
+@patch("schwab_mcp.auth.auth.client_from_access_functions")
+def test_easy_client_reuses_valid_token(mock_caf: Any, mock_login: Any) -> None:
+    """When a fresh token exists, easy_client returns without entering login flow."""
+    dummy = _make_dummy_client(token_age=100.0)
+    mock_caf.return_value = dummy
+
+    manager = DummyTokenManager(exists=True)
+    result = mcp_auth.easy_client(
+        FAKE_CLIENT_ID,
+        FAKE_CLIENT_SECRET,
+        VALID_CALLBACK_URL,
+        manager,
+        max_token_age=mcp_auth.DEFAULT_MAX_TOKEN_AGE_SECONDS,
+    )
+
+    assert result is dummy
+    mock_caf.assert_called_once()
+    mock_login.assert_not_called()
+
+
+@patch("schwab_mcp.auth.client_from_login_flow")
+@patch("schwab_mcp.auth.auth.client_from_access_functions")
+def test_easy_client_falls_through_when_no_token(
+    mock_caf: Any, mock_login: Any
+) -> None:
+    """When no token exists, easy_client delegates to client_from_login_flow."""
+    dummy = _make_dummy_client()
+    mock_login.return_value = dummy
+
+    manager = DummyTokenManager(exists=False)
+    result = mcp_auth.easy_client(
+        FAKE_CLIENT_ID,
+        FAKE_CLIENT_SECRET,
+        VALID_CALLBACK_URL,
+        manager,
+    )
+
+    assert result is dummy
+    mock_caf.assert_not_called()
+    mock_login.assert_called_once()
+
+
+@patch("schwab_mcp.auth.client_from_login_flow")
+@patch("schwab_mcp.auth.auth.client_from_access_functions")
+def test_easy_client_rejects_stale_token(mock_caf: Any, mock_login: Any) -> None:
+    """Token older than max_token_age triggers login flow."""
+    max_age = 100
+    stale_client = _make_dummy_client(token_age=float(max_age + 1))
+    mock_caf.return_value = stale_client
+
+    fresh_client = _make_dummy_client(token_age=0.0)
+    mock_login.return_value = fresh_client
+
+    manager = DummyTokenManager(exists=True)
+    result = mcp_auth.easy_client(
+        FAKE_CLIENT_ID,
+        FAKE_CLIENT_SECRET,
+        VALID_CALLBACK_URL,
+        manager,
+        max_token_age=max_age,
+    )
+
+    assert result is fresh_client
+    mock_login.assert_called_once()
+
+
+@patch("schwab_mcp.auth.client_from_login_flow")
+@patch("schwab_mcp.auth.auth.client_from_access_functions")
+def test_easy_client_max_token_age_none_skips_age_check(
+    mock_caf: Any, mock_login: Any
+) -> None:
+    """max_token_age=None disables the age check; any token age is accepted."""
+    ancient_client = _make_dummy_client(token_age=99_999_999.0)
+    mock_caf.return_value = ancient_client
+
+    manager = DummyTokenManager(exists=True)
+    result = mcp_auth.easy_client(
+        FAKE_CLIENT_ID,
+        FAKE_CLIENT_SECRET,
+        VALID_CALLBACK_URL,
+        manager,
+        max_token_age=None,
+    )
+
+    assert result is ancient_client
+    mock_login.assert_not_called()
+
+
+@patch("schwab_mcp.auth.client_from_login_flow")
+@patch("schwab_mcp.auth.auth.client_from_access_functions")
+def test_easy_client_max_token_age_zero_skips_age_check(
+    mock_caf: Any, mock_login: Any
+) -> None:
+    """max_token_age=0 treats effective age as 0 (no age check), not as 'disable'."""
+    # When effective_max_token_age == 0, the condition `> 0` is False → no eviction.
+    any_age_client = _make_dummy_client(token_age=50_000.0)
+    mock_caf.return_value = any_age_client
+
+    manager = DummyTokenManager(exists=True)
+    result = mcp_auth.easy_client(
+        FAKE_CLIENT_ID,
+        FAKE_CLIENT_SECRET,
+        VALID_CALLBACK_URL,
+        manager,
+        max_token_age=0,
+    )
+
+    assert result is any_age_client
+    mock_login.assert_not_called()
+
+
+def test_easy_client_negative_max_token_age_raises() -> None:
+    """Negative max_token_age raises ValueError."""
+    manager = DummyTokenManager(exists=False)
+    with pytest.raises(ValueError, match="max_token_age must be positive"):
+        mcp_auth.easy_client(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            VALID_CALLBACK_URL,
+            manager,
+            max_token_age=-1,
+        )
+
+
+# ---------------------------------------------------------------------------
+# client_from_login_flow: hostname validation
+# ---------------------------------------------------------------------------
+
+
+def test_client_from_login_flow_rejects_non_localhost_hostname() -> None:
+    """Non-127.0.0.1 hostnames are rejected with a descriptive ValueError."""
+    manager = DummyTokenManager(exists=False)
+    with pytest.raises(ValueError, match="Disallowed hostname"):
+        mcp_auth.client_from_login_flow(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            "https://localhost:8182",
+            manager,
+        )
+
+
+def test_client_from_login_flow_rejects_public_hostname() -> None:
+    """Public hostnames are also rejected."""
+    manager = DummyTokenManager(exists=False)
+    with pytest.raises(ValueError, match="Disallowed hostname"):
+        mcp_auth.client_from_login_flow(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            "https://example.com:8182",
+            manager,
+        )
+
+
+def test_client_from_login_flow_negative_timeout_raises() -> None:
+    """Negative callback_timeout raises ValueError before any network activity."""
+    manager = DummyTokenManager(exists=False)
+    with pytest.raises(ValueError, match="callback_timeout must be positive"):
+        mcp_auth.client_from_login_flow(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            VALID_CALLBACK_URL,
+            manager,
+            callback_timeout=-1.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# client_from_login_flow: happy-path (mocked subprocess + httpx + browser)
+# ---------------------------------------------------------------------------
+
+
+def _make_login_flow_mocks(
+    *,
+    queue_items: list[Any],
+    httpx_connect_error_count: int = 0,
+) -> dict[str, Any]:
+    """Build a dict of patches that drive client_from_login_flow without I/O."""
+    # Process mock: starts immediately, has a pid, never exits early
+    mock_process = MagicMock()
+    mock_process.pid = 9999
+    mock_process.exitcode = None  # server appears to be running
+
+    mock_process_cls = MagicMock(return_value=mock_process)
+
+    # Queue mock
+    mock_queue_instance = MagicMock()
+    # Simulate httpx.ConnectError a few times before succeeding
+    httpx_call_count: list[int] = [0]
+
+    def fake_httpx_get(*args: Any, **kwargs: Any) -> MagicMock:
+        httpx_call_count[0] += 1
+        if httpx_call_count[0] <= httpx_connect_error_count:
+            raise _httpx.ConnectError("not ready")
+        return MagicMock()
+
+    # output_queue.get(): first return received_url, then raise Empty
+    items = list(queue_items)
+
+    def fake_queue_get(**kwargs: Any) -> str:
+        if items:
+            return items.pop(0)
+        raise queue.Empty
+
+    mock_queue_instance.get.side_effect = fake_queue_get
+    mock_queue_cls = MagicMock(return_value=mock_queue_instance)
+
+    mock_auth_context = DummyAuthContext()
+
+    return {
+        "mock_process_cls": mock_process_cls,
+        "mock_process": mock_process,
+        "mock_queue_cls": mock_queue_cls,
+        "mock_queue_instance": mock_queue_instance,
+        "fake_httpx_get": fake_httpx_get,
+        "mock_auth_context": mock_auth_context,
+    }
+
+
+@patch("schwab_mcp.auth.auth.client_from_received_url")
+@patch("schwab_mcp.auth.auth.get_auth_context")
+@patch("schwab_mcp.auth.auth.webbrowser")
+@patch("schwab_mcp.auth.auth.time")
+@patch("schwab_mcp.auth.auth.httpx")
+@patch("schwab_mcp.auth.auth.psutil")
+@patch("schwab_mcp.auth.QueueType")
+@patch("schwab_mcp.auth.ProcessType")
+def test_client_from_login_flow_happy_path(
+    mock_process_cls: Any,
+    mock_queue_cls: Any,
+    mock_psutil: Any,
+    mock_httpx: Any,
+    mock_time: Any,
+    mock_webbrowser: Any,
+    mock_get_auth_context: Any,
+    mock_client_from_received_url: Any,
+) -> None:
+    """Happy path: server starts, redirect arrives, client returned."""
+    mocks = _make_login_flow_mocks(queue_items=["https://127.0.0.1:8182/?code=abc"])
+
+    mock_process_cls.return_value = mocks["mock_process"]
+    mock_queue_cls.return_value = mocks["mock_queue_instance"]
+    mock_httpx.get.side_effect = mocks["fake_httpx_get"]
+    mock_httpx.ConnectError = _httpx.ConnectError
+    mock_get_auth_context.return_value = mocks["mock_auth_context"]
+
+    # Make time advance past timeout check: use a large timeout so we don't time out
+    call_count: list[int] = [0]
+
+    def fake_time_time() -> float:
+        call_count[0] += 1
+        # First call: "now" = 0 (sets up timeout_time = 300)
+        # Subsequent calls: still 0 so we never hit timeout
+        return 0.0
+
+    mock_time.time = fake_time_time
+    # Patch the module-level __TIME_TIME used in auth.py
+    with patch.object(schwab_auth, "__TIME_TIME", fake_time_time):
+        dummy_client = DummyClient()
+        mock_client_from_received_url.return_value = dummy_client
+
+        manager = DummyTokenManager(exists=False)
+        result = mcp_auth.client_from_login_flow(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            VALID_CALLBACK_URL,
+            manager,
+            interactive=False,
+            callback_timeout=300.0,
+        )
+
+    assert result is dummy_client
+    mock_client_from_received_url.assert_called_once()
+    # Verify the received_url was passed through
+    call_kwargs = mock_client_from_received_url.call_args
+    assert "https://127.0.0.1:8182/?code=abc" in call_kwargs.args
+
+
+@patch("schwab_mcp.auth.auth.client_from_received_url")
+@patch("schwab_mcp.auth.auth.get_auth_context")
+@patch("schwab_mcp.auth.auth.webbrowser")
+@patch("schwab_mcp.auth.auth.time")
+@patch("schwab_mcp.auth.auth.httpx")
+@patch("schwab_mcp.auth.auth.psutil")
+@patch("schwab_mcp.auth.QueueType")
+@patch("schwab_mcp.auth.ProcessType")
+def test_client_from_login_flow_httpx_retry_then_succeeds(
+    mock_process_cls: Any,
+    mock_queue_cls: Any,
+    mock_psutil: Any,
+    mock_httpx: Any,
+    mock_time: Any,
+    mock_webbrowser: Any,
+    mock_get_auth_context: Any,
+    mock_client_from_received_url: Any,
+) -> None:
+    """Server readiness polling retries on ConnectError before succeeding."""
+    mocks = _make_login_flow_mocks(
+        queue_items=["https://127.0.0.1:8182/?code=xyz"],
+        httpx_connect_error_count=2,
+    )
+
+    mock_process_cls.return_value = mocks["mock_process"]
+    mock_queue_cls.return_value = mocks["mock_queue_instance"]
+    mock_httpx.get.side_effect = mocks["fake_httpx_get"]
+    mock_httpx.ConnectError = _httpx.ConnectError
+    mock_get_auth_context.return_value = mocks["mock_auth_context"]
+
+    with patch.object(schwab_auth, "__TIME_TIME", lambda: 0.0):
+        dummy_client = DummyClient()
+        mock_client_from_received_url.return_value = dummy_client
+
+        manager = DummyTokenManager(exists=False)
+        result = mcp_auth.client_from_login_flow(
+            FAKE_CLIENT_ID,
+            FAKE_CLIENT_SECRET,
+            VALID_CALLBACK_URL,
+            manager,
+            interactive=False,
+            callback_timeout=300.0,
+        )
+
+    assert result is dummy_client
+    # httpx.get was called at least 3 times (2 failures + 1 success)
+    assert mock_httpx.get.call_count >= 3
+
+
+@patch("schwab_mcp.auth.auth.client_from_received_url")
+@patch("schwab_mcp.auth.auth.get_auth_context")
+@patch("schwab_mcp.auth.auth.webbrowser")
+@patch("schwab_mcp.auth.auth.time")
+@patch("schwab_mcp.auth.auth.httpx")
+@patch("schwab_mcp.auth.auth.psutil")
+@patch("schwab_mcp.auth.QueueType")
+@patch("schwab_mcp.auth.ProcessType")
+def test_client_from_login_flow_times_out(
+    mock_process_cls: Any,
+    mock_queue_cls: Any,
+    mock_psutil: Any,
+    mock_httpx: Any,
+    mock_time: Any,
+    mock_webbrowser: Any,
+    mock_get_auth_context: Any,
+    mock_client_from_received_url: Any,
+) -> None:
+    """No redirect received before timeout → RedirectTimeoutError raised."""
+    mocks = _make_login_flow_mocks(queue_items=[])  # nothing in queue
+
+    mock_process_cls.return_value = mocks["mock_process"]
+    mock_queue_cls.return_value = mocks["mock_queue_instance"]
+    mock_httpx.get.return_value = MagicMock()  # server ready immediately
+    mock_httpx.ConnectError = _httpx.ConnectError
+    mock_get_auth_context.return_value = mocks["mock_auth_context"]
+
+    # Time advances past timeout on the second call inside the wait loop
+    time_calls: list[int] = [0]
+
+    def advancing_time() -> float:
+        time_calls[0] += 1
+        # First call: sets now=0 → timeout_time = now + 1 = 1
+        # Second call in loop: returns 2 (> timeout_time) → triggers break
+        return float(time_calls[0]) * 2.0
+
+    with patch.object(schwab_auth, "__TIME_TIME", advancing_time):
+        manager = DummyTokenManager(exists=False)
+        with pytest.raises(schwab_auth.RedirectTimeoutError):
+            mcp_auth.client_from_login_flow(
+                FAKE_CLIENT_ID,
+                FAKE_CLIENT_SECRET,
+                VALID_CALLBACK_URL,
+                manager,
+                interactive=False,
+                callback_timeout=1.0,
+            )

--- a/tests/test_cli_auth.py
+++ b/tests/test_cli_auth.py
@@ -41,3 +41,53 @@ def test_auth_command_uses_max_token_age(monkeypatch, tmp_path):
     assert result.exit_code == 0
     assert captured["token_path"] == str(token_file)
     assert captured["easy_client_kwargs"]["max_token_age"] == cli.TOKEN_MAX_AGE_SECONDS
+
+
+def test_auth_command_returns_error_on_exception(monkeypatch, tmp_path):
+    """When easy_client raises, the auth command prints an error but does not re-raise."""
+
+    class DummyManager:
+        def __init__(self, path: str) -> None:
+            self.path = path
+
+    def fake_easy_client(**kwargs):
+        raise RuntimeError("network unavailable")
+
+    monkeypatch.setattr(cli.tokens, "Manager", DummyManager)
+    monkeypatch.setattr(cli.schwab_auth, "easy_client", fake_easy_client)
+
+    runner = CliRunner()
+    token_file = tmp_path / "token.yaml"
+    result = runner.invoke(
+        cli.cli,
+        [
+            "auth",
+            "--token-path",
+            str(token_file),
+            "--client-id",
+            "cid",
+            "--client-secret",
+            "secret",
+        ],
+    )
+
+    # The command catches the exception and returns 1 via the non-zero exit path
+    assert "Authentication failed: network unavailable" in result.output
+    # Note: the command returns 1 but Click converts it via the function return value
+
+
+def test_cli_main_entrypoint_delegates_to_cli_group(monkeypatch):
+    """main() must call through to the cli() Click group (entry point contract)."""
+    import schwab_mcp.cli as cli_module
+
+    called: dict[str, Any] = {}
+
+    def fake_cli_group():
+        called["invoked"] = True
+        return 0
+
+    monkeypatch.setattr(cli_module, "cli", fake_cli_group)
+    result = cli_module.main()
+
+    assert called.get("invoked") is True
+    assert result == 0

--- a/tests/test_cli_server_write_modes.py
+++ b/tests/test_cli_server_write_modes.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from click.testing import CliRunner
 from typing import Any
 
+from schwab.client import AsyncClient
+
 from schwab_mcp import cli
 from schwab_mcp.approvals import (
     ApprovalDecision,
@@ -179,3 +181,298 @@ def test_server_json_flag_enables_json_output(monkeypatch):
 
     assert result.exit_code == 0
     assert captured["use_json"] is True
+
+
+# ---------------------------------------------------------------------------
+# Missing-credentials path for the server command
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_with_error_when_credentials_missing(monkeypatch, tmp_path):
+    """server command calls send_error_response and exits 1 when creds are absent."""
+
+    creds_path = tmp_path / "nonexistent.yaml"
+    monkeypatch.setattr(cli.tokens, "credentials_path", lambda app: str(creds_path))
+    monkeypatch.delenv("SCHWAB_CLIENT_ID", raising=False)
+    monkeypatch.delenv("SCHWAB_CLIENT_SECRET", raising=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["server", "--token-path", str(tmp_path / "token.yaml")],
+    )
+
+    assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# Non-async client / client init exception paths
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_when_easy_client_raises(monkeypatch):
+    """When easy_client raises, server sends a 500 error response and exits 1."""
+    monkeypatch.setattr(cli, "AsyncClient", FakeAsyncClient)
+
+    def boom_easy_client(**_kwargs):
+        raise RuntimeError("auth exploded")
+
+    monkeypatch.setattr(cli.schwab_auth, "easy_client", boom_easy_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "auth exploded" in result.output
+
+
+def test_server_exits_when_client_is_not_async(monkeypatch):
+    """When easy_client returns a non-AsyncClient, server sends a 500 error and exits 1."""
+
+    class SyncClient:
+        """A fake non-async client."""
+
+    # Make isinstance(client, AsyncClient) return False by patching AsyncClient
+    # to a type the SyncClient does NOT inherit from.
+    monkeypatch.setattr(cli, "AsyncClient", AsyncClient)
+
+    def sync_easy_client(**_kwargs):
+        return SyncClient()
+
+    monkeypatch.setattr(cli.schwab_auth, "easy_client", sync_easy_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Async client required" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Token age expiry
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_when_token_is_too_old(monkeypatch):
+    """When the token is older than the max age, server sends a 401 error and exits 1."""
+
+    class StaleAsyncClient(FakeAsyncClient):
+        def token_age(self) -> int:
+            return cli.TOKEN_MAX_AGE_SECONDS + 1  # expired
+
+    monkeypatch.setattr(cli, "AsyncClient", StaleAsyncClient)
+
+    def fake_easy_client(**_kwargs):
+        return StaleAsyncClient()
+
+    monkeypatch.setattr(cli.schwab_auth, "easy_client", fake_easy_client)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["server", "--client-id", "client", "--client-secret", "secret"],
+    )
+
+    assert result.exit_code == 1
+    assert "Token is older than 5 days" in result.output
+
+
+# ---------------------------------------------------------------------------
+# SCHWAB_MCP_DISCORD_APPROVERS env var parsing
+# ---------------------------------------------------------------------------
+
+
+def test_server_reads_approvers_from_env_var(monkeypatch):
+    """SCHWAB_MCP_DISCORD_APPROVERS env var is parsed as a comma-separated list."""
+    captured: dict[str, Any] = {}
+    _patch_common(monkeypatch, captured)
+    monkeypatch.setattr(cli, "DiscordApprovalManager", DummyDiscordApprovalManager)
+    monkeypatch.setenv("SCHWAB_MCP_DISCORD_APPROVERS", "111, 222, 333")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+            "--discord-token",
+            "tok",
+            "--discord-channel-id",
+            "999",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert captured["allow_write"] is True
+    manager = captured["approval_manager"]
+    assert isinstance(manager, DummyDiscordApprovalManager)
+    assert manager.settings.approver_ids == frozenset({111, 222, 333})
+
+
+# ---------------------------------------------------------------------------
+# Missing Discord token/channel
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_when_discord_token_missing(monkeypatch):
+    """Discord channel provided but no token → error exit."""
+    captured: dict[str, Any] = {}
+    _patch_common(monkeypatch, captured)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+            "--discord-channel-id",
+            "123",
+            "--discord-approver",
+            "456",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Discord approval configuration is required" in result.output
+
+
+def test_server_exits_when_discord_channel_missing(monkeypatch):
+    """Discord token provided but no channel ID → error exit."""
+    captured: dict[str, Any] = {}
+    _patch_common(monkeypatch, captured)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+            "--discord-token",
+            "tok",
+            "--discord-approver",
+            "456",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "Discord approval configuration is required" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Empty approver list
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_when_approver_list_empty(monkeypatch):
+    """Discord token + channel but empty approver list → error exit."""
+    captured: dict[str, Any] = {}
+    _patch_common(monkeypatch, captured)
+    monkeypatch.setattr(cli, "DiscordApprovalManager", DummyDiscordApprovalManager)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+            "--discord-token",
+            "tok",
+            "--discord-channel-id",
+            "123",
+            # no --discord-approver and no env var → empty frozenset
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "approver list cannot be empty" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --jesus-take-the-wheel + discord token warning
+# ---------------------------------------------------------------------------
+
+
+def test_server_warns_when_jesus_flag_and_discord_token_both_set(monkeypatch):
+    """--jesus-take-the-wheel with a Discord token emits a bypass warning."""
+    captured: dict[str, Any] = {}
+    _patch_common(monkeypatch, captured)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        [
+            "server",
+            "--client-id",
+            "client",
+            "--client-secret",
+            "secret",
+            "--jesus-take-the-wheel",
+            "--discord-token",
+            "tok",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    # Warning goes to stderr
+    assert "bypasses Discord approvals" in (result.output + (result.stderr or ""))
+
+
+# ---------------------------------------------------------------------------
+# Server run exception handling
+# ---------------------------------------------------------------------------
+
+
+def test_server_exits_when_server_run_raises(monkeypatch):
+    """When SchwabMCPServer.run() raises, CLI sends a 500 error response and exits 1."""
+    monkeypatch.setattr(cli, "AsyncClient", FakeAsyncClient)
+
+    def fake_easy_client(**_kwargs):
+        return FakeAsyncClient()
+
+    monkeypatch.setattr(cli.schwab_auth, "easy_client", fake_easy_client)
+
+    def fake_run(func, backend="asyncio"):
+        raise RuntimeError("server exploded during run")
+
+    monkeypatch.setattr(cli.anyio, "run", fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.cli,
+        ["server", "--client-id", "client", "--client-secret", "secret"],
+    )
+
+    assert result.exit_code == 1
+    assert "server exploded during run" in result.output

--- a/tests/test_discord_approvals.py
+++ b/tests/test_discord_approvals.py
@@ -1,0 +1,633 @@
+"""Unit tests for schwab_mcp/approvals/discord.py."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from schwab_mcp.approvals.base import ApprovalDecision, ApprovalRequest
+from schwab_mcp.approvals.discord import (
+    DiscordApprovalManager,
+    DiscordApprovalSettings,
+    _PendingApproval,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+APPROVER_ID = 111
+OTHER_USER_ID = 222
+CHANNEL_ID = 999
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_settings(
+    *,
+    approver_ids: frozenset[int] = frozenset({APPROVER_ID}),
+    timeout_seconds: float = 5.0,
+) -> DiscordApprovalSettings:
+    return DiscordApprovalSettings(
+        token="fake-token",
+        channel_id=CHANNEL_ID,
+        approver_ids=approver_ids,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def make_request(
+    *,
+    id: str = "approval-1",
+    tool_name: str = "place_order",
+    request_id: str = "req-1",
+    client_id: str | None = "client-1",
+    arguments: dict[str, str] | None = None,
+) -> ApprovalRequest:
+    return ApprovalRequest(
+        id=id,
+        tool_name=tool_name,
+        request_id=request_id,
+        client_id=client_id,
+        arguments=arguments
+        if arguments is not None
+        else {"symbol": "AAPL", "qty": "10"},
+    )
+
+
+def make_manager(
+    settings: DiscordApprovalSettings | None = None,
+) -> DiscordApprovalManager:
+    """Return a manager whose _ApprovalClient is fully mocked out."""
+    if settings is None:
+        settings = make_settings()
+    with patch("schwab_mcp.approvals.discord._ApprovalClient"):
+        mgr = DiscordApprovalManager(settings)
+
+    # Replace with a clean MagicMock so we can configure it per-test
+    client: Any = MagicMock()
+    client.close = AsyncMock()
+    client.start = AsyncMock()
+    client.get_channel = MagicMock(return_value=None)
+    client.fetch_channel = AsyncMock()
+    mgr._client = client
+    return mgr
+
+
+def make_fake_channel() -> Any:
+    channel: Any = MagicMock()
+    channel.id = CHANNEL_ID
+    channel.send = AsyncMock()
+    return channel
+
+
+def make_fake_message(channel: Any) -> Any:
+    msg: Any = MagicMock()
+    msg.id = 42
+    msg.channel = channel
+    msg.add_reaction = AsyncMock()
+    msg.edit = AsyncMock()
+    return msg
+
+
+def make_fake_reaction(msg: Any, emoji: str) -> Any:
+    reaction: Any = MagicMock()
+    reaction.emoji = emoji
+    reaction.message = msg
+    reaction.remove = AsyncMock()
+    return reaction
+
+
+def make_fake_user(user_id: int, *, bot: bool = False) -> Any:
+    user: Any = MagicMock()
+    user.id = user_id
+    user.bot = bot
+    return user
+
+
+def inject_pending(
+    mgr: DiscordApprovalManager, msg: Any
+) -> asyncio.Future[ApprovalDecision]:
+    """Register a _PendingApproval and return the future for direct resolution."""
+    future: asyncio.Future[ApprovalDecision] = (
+        asyncio.get_running_loop().create_future()
+    )
+    mgr._pending[msg.id] = _PendingApproval(
+        request=make_request(), future=future, message=msg
+    )
+    return future
+
+
+# ---------------------------------------------------------------------------
+# Constructor validation
+# ---------------------------------------------------------------------------
+
+
+def test_requires_at_least_one_approver_id() -> None:
+    with pytest.raises(ValueError, match="at least one approver ID"):
+        with patch("schwab_mcp.approvals.discord._ApprovalClient"):
+            DiscordApprovalManager(make_settings(approver_ids=frozenset()))
+
+
+# ---------------------------------------------------------------------------
+# start() / stop() lifecycle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_start_launches_runner_task_and_waits_for_ready() -> None:
+    mgr = make_manager()
+    # Pre-set the ready event so start() does not block
+    mgr._ready.set()
+
+    async def fake_run_client() -> None:
+        await asyncio.sleep(0)
+
+    mgr._run_client = fake_run_client  # type: ignore[method-assign]
+
+    await mgr.start()
+    assert mgr._runner is not None
+
+    # Clean up
+    runner = mgr._runner
+    runner.cancel()
+    try:
+        await runner
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+@pytest.mark.anyio
+async def test_start_is_idempotent() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    async def fake_run_client() -> None:
+        await asyncio.sleep(100)
+
+    mgr._run_client = fake_run_client  # type: ignore[method-assign]
+
+    await mgr.start()
+    first_runner = mgr._runner
+
+    await mgr.start()  # second call — must be a no-op
+    assert mgr._runner is first_runner
+
+    runner = mgr._runner
+    if runner is not None:
+        runner.cancel()
+        try:
+            await runner
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
+@pytest.mark.anyio
+async def test_stop_clears_state() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+    mgr._channel = make_fake_channel()
+
+    async def noop() -> None:
+        pass
+
+    loop = asyncio.get_running_loop()
+    mgr._runner = loop.create_task(noop())
+    await asyncio.sleep(0)  # let the task finish naturally
+
+    await mgr.stop()
+
+    assert mgr._runner is None
+    assert mgr._channel is None
+    assert not mgr._ready.is_set()
+    mgr._client.close.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_stop_when_not_started_is_safe() -> None:
+    mgr = make_manager()
+    await mgr.stop()
+    mgr._client.close.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# _handle_ready()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_handle_ready_sets_ready_event() -> None:
+    mgr = make_manager()
+    assert not mgr._ready.is_set()
+    await mgr._handle_ready()
+    assert mgr._ready.is_set()
+
+
+# ---------------------------------------------------------------------------
+# _ensure_channel()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_ensure_channel_returns_cached_channel() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+    channel = make_fake_channel()
+    mgr._channel = channel
+
+    result = await mgr._ensure_channel()
+
+    assert result is channel
+    mgr._client.get_channel.assert_not_called()  # type: ignore[attr-defined]
+    mgr._client.fetch_channel.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_ensure_channel_uses_get_channel_when_available() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+    channel: Any = MagicMock(spec=discord.TextChannel)
+    mgr._client.get_channel.return_value = channel  # type: ignore[attr-defined]
+
+    result = await mgr._ensure_channel()
+
+    assert result is channel
+    mgr._client.fetch_channel.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_ensure_channel_fetches_when_get_channel_returns_none() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+    channel: Any = MagicMock(spec=discord.TextChannel)
+    mgr._client.get_channel.return_value = None  # type: ignore[attr-defined]
+    mgr._client.fetch_channel = AsyncMock(return_value=channel)  # type: ignore[attr-defined]
+
+    result = await mgr._ensure_channel()
+
+    assert result is channel
+    mgr._client.fetch_channel.assert_awaited_once_with(CHANNEL_ID)  # type: ignore[attr-defined]
+    assert mgr._channel is channel
+
+
+@pytest.mark.anyio
+async def test_ensure_channel_raises_if_not_messageable() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+    bad_channel: Any = MagicMock(spec=discord.VoiceChannel)
+    mgr._client.get_channel.return_value = None  # type: ignore[attr-defined]
+    mgr._client.fetch_channel = AsyncMock(return_value=bad_channel)  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="not messageable"):
+        await mgr._ensure_channel()
+
+
+# ---------------------------------------------------------------------------
+# require(): success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_require_approved_via_reaction() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    async def drive_approval() -> None:
+        await asyncio.sleep(0)
+        pending = mgr._pending.get(msg.id)
+        if pending and not pending.future.done():
+            pending.future.set_result(ApprovalDecision.APPROVED)
+
+    asyncio.get_running_loop().create_task(drive_approval())
+    decision = await mgr.require(make_request())
+
+    assert decision == ApprovalDecision.APPROVED
+    channel.send.assert_awaited_once()
+    msg.add_reaction.assert_any_await("✅")
+    msg.add_reaction.assert_any_await("❌")
+
+
+@pytest.mark.anyio
+async def test_require_denied_via_reaction() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    async def drive_denial() -> None:
+        await asyncio.sleep(0)
+        pending = mgr._pending.get(msg.id)
+        if pending and not pending.future.done():
+            pending.future.set_result(ApprovalDecision.DENIED)
+
+    asyncio.get_running_loop().create_task(drive_denial())
+    decision = await mgr.require(make_request())
+
+    assert decision == ApprovalDecision.DENIED
+
+
+@pytest.mark.anyio
+async def test_require_cleans_up_pending_after_decision() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    async def resolve() -> None:
+        await asyncio.sleep(0)
+        pending = mgr._pending.get(msg.id)
+        if pending:
+            pending.future.set_result(ApprovalDecision.APPROVED)
+
+    asyncio.get_running_loop().create_task(resolve())
+    await mgr.require(make_request())
+
+    assert msg.id not in mgr._pending
+
+
+@pytest.mark.anyio
+async def test_require_sends_pending_embed_with_tool_name() -> None:
+    """require() must pass an embed whose description mentions the tool name."""
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    async def resolve() -> None:
+        await asyncio.sleep(0)
+        pending = mgr._pending.get(msg.id)
+        if pending:
+            pending.future.set_result(ApprovalDecision.APPROVED)
+
+    asyncio.get_running_loop().create_task(resolve())
+    await mgr.require(make_request(tool_name="my_special_tool"))
+
+    call_kwargs = channel.send.call_args
+    embed: discord.Embed = call_kwargs.kwargs["embed"]
+    assert "my_special_tool" in (embed.description or "")
+
+
+# ---------------------------------------------------------------------------
+# require(): timeout path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_require_times_out_returns_expired() -> None:
+    mgr = make_manager(make_settings(timeout_seconds=0.01))
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    decision = await mgr.require(make_request())
+
+    assert decision == ApprovalDecision.EXPIRED
+    msg.edit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_require_times_out_cleans_up_pending() -> None:
+    mgr = make_manager(make_settings(timeout_seconds=0.01))
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    await mgr.require(make_request())
+
+    assert msg.id not in mgr._pending
+
+
+# ---------------------------------------------------------------------------
+# require(): HTTPException on add_reaction
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_require_denied_when_add_reaction_raises_http_exception() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    msg.add_reaction = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=403), "Forbidden")
+    )
+    channel.send = AsyncMock(return_value=msg)
+    mgr._channel = channel
+
+    decision = await mgr.require(make_request())
+
+    assert decision == ApprovalDecision.DENIED
+    msg.edit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _handle_reaction_add(): authorization and routing logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_approved_by_authorized_user() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "✅")
+    user = make_fake_user(APPROVER_ID)
+
+    await mgr._handle_reaction_add(reaction, user)
+
+    assert future.done()
+    assert future.result() == ApprovalDecision.APPROVED
+    msg.edit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_denied_by_authorized_user() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "❌")
+    user = make_fake_user(APPROVER_ID)
+
+    await mgr._handle_reaction_add(reaction, user)
+
+    assert future.result() == ApprovalDecision.DENIED
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_ignores_bot_reactions() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "✅")
+    bot_user = make_fake_user(APPROVER_ID, bot=True)
+
+    await mgr._handle_reaction_add(reaction, bot_user)
+
+    assert not future.done()
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_ignores_wrong_channel() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    channel.id = 12345  # different from CHANNEL_ID
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "✅")
+    user = make_fake_user(APPROVER_ID)
+
+    await mgr._handle_reaction_add(reaction, user)
+
+    assert not future.done()
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_ignores_unknown_message() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    # Nothing registered in _pending — should complete silently
+
+    reaction = make_fake_reaction(msg, "✅")
+    user = make_fake_user(APPROVER_ID)
+
+    await mgr._handle_reaction_add(reaction, user)  # must not raise
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_ignores_unrecognized_emoji() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "🤔")
+    user = make_fake_user(APPROVER_ID)
+
+    await mgr._handle_reaction_add(reaction, user)
+
+    assert not future.done()
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_removes_unauthorized_user_reaction() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "✅")
+    unauthorized_user = make_fake_user(OTHER_USER_ID)
+
+    await mgr._handle_reaction_add(reaction, unauthorized_user)
+
+    assert not future.done()
+    reaction.remove.assert_awaited_once_with(unauthorized_user)
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_unauthorized_remove_survives_http_exception() -> (
+    None
+):
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+
+    reaction = make_fake_reaction(msg, "✅")
+    reaction.remove = AsyncMock(
+        side_effect=discord.HTTPException(MagicMock(status=403), "Forbidden")
+    )
+    unauthorized_user = make_fake_user(OTHER_USER_ID)
+
+    await mgr._handle_reaction_add(reaction, unauthorized_user)  # must not raise
+
+    assert not future.done()
+
+
+@pytest.mark.anyio
+async def test_handle_reaction_add_skips_already_resolved_future() -> None:
+    mgr = make_manager()
+    mgr._ready.set()
+
+    channel = make_fake_channel()
+    msg = make_fake_message(channel)
+    future = inject_pending(mgr, msg)
+    future.set_result(ApprovalDecision.APPROVED)  # already resolved
+
+    reaction = make_fake_reaction(msg, "✅")
+    user = make_fake_user(APPROVER_ID)
+
+    # Must not raise InvalidStateError on future.set_result
+    await mgr._handle_reaction_add(reaction, user)
+    # _finalize_message / msg.edit must not be called a second time
+    msg.edit.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# authorized_user_ids() static helper
+# ---------------------------------------------------------------------------
+
+
+def test_authorized_user_ids_normalizes_sequence() -> None:
+    result = DiscordApprovalManager.authorized_user_ids([1, 2, 3])
+    assert result == frozenset({1, 2, 3})
+
+
+def test_authorized_user_ids_returns_empty_frozenset_for_none() -> None:
+    assert DiscordApprovalManager.authorized_user_ids(None) == frozenset()
+
+
+def test_authorized_user_ids_returns_empty_frozenset_for_empty_list() -> None:
+    assert DiscordApprovalManager.authorized_user_ids([]) == frozenset()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,15 +1,23 @@
 import asyncio
+import inspect
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import Annotated, Any, Callable, Union, cast
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import FastMCP, Context as MCPContext
 from mcp.server.fastmcp.tools import Tool
 from mcp.types import ToolAnnotations
 from schwab.client import AsyncClient
 
+import pytest
 import schwab_mcp.tools as tools_module
-from schwab_mcp.tools._registration import register_tool
-from schwab_mcp.context import SchwabContext
+from schwab_mcp.tools import _registration
+from schwab_mcp.tools._registration import (
+    register_tool,
+    _is_context_annotation,
+    _format_argument,
+)
+from schwab_mcp.context import SchwabContext, SchwabServerContext
+from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
 
 async def _dummy_tool(ctx: SchwabContext) -> str:  # noqa: ARG001
@@ -122,6 +130,23 @@ def test_register_tool_applies_result_transform() -> None:
     assert captured["payload"] == {"ok": "yes"}
 
 
+def test_result_transform_handles_sync_tool() -> None:
+    """_wrap_result_transform works when the wrapped function returns synchronously."""
+    server = FastMCP(name="sync-transform")
+
+    def sync_tool() -> str:  # type: ignore[return-value]
+        return "raw"
+
+    register_tool(server, sync_tool, result_transform=str.upper)  # type: ignore[arg-type]
+    tool = _tool_by_name(server, "sync_tool")
+
+    async def runner() -> str:
+        return await tool.fn()
+
+    result = asyncio.run(runner())
+    assert result == "RAW"
+
+
 def test_result_transform_preserves_strings() -> None:
     server = FastMCP(name="string-transform")
 
@@ -145,3 +170,226 @@ def test_result_transform_preserves_strings() -> None:
     result = asyncio.run(runner())
     assert result == "already-string"
     assert captured["payload"] == "already-string"
+
+
+# ---------------------------------------------------------------------------
+# _is_context_annotation edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_is_context_annotation_none_returns_false() -> None:
+    assert _is_context_annotation(None) is False
+
+
+def test_is_context_annotation_empty_returns_false() -> None:
+    assert _is_context_annotation(inspect._empty) is False  # type: ignore[attr-defined]
+
+
+def test_is_context_annotation_string_schwabcontext_returns_true() -> None:
+    assert _is_context_annotation("SchwabContext") is True
+
+
+def test_is_context_annotation_other_string_returns_false() -> None:
+    assert _is_context_annotation("str") is False
+
+
+def test_is_context_annotation_annotated_type_returns_true() -> None:
+    annotated = Annotated[SchwabContext, "the mcp context"]
+    assert _is_context_annotation(annotated) is True
+
+
+def test_is_context_annotation_union_containing_context_returns_true() -> None:
+    union = Union[SchwabContext, None]
+    assert _is_context_annotation(union) is True
+
+
+def test_is_context_annotation_union_without_context_returns_false() -> None:
+    union = Union[str, int]
+    assert _is_context_annotation(union) is False
+
+
+def test_is_context_annotation_unrelated_type_returns_false() -> None:
+    assert _is_context_annotation(int) is False
+
+
+def test_is_context_annotation_generic_with_other_origin_returns_false() -> None:
+    # list[str] has a non-Annotated, non-Union origin → falls through to False
+    assert _is_context_annotation(list[str]) is False
+
+
+# ---------------------------------------------------------------------------
+# _format_argument truncation
+# ---------------------------------------------------------------------------
+
+
+def test_format_argument_truncates_long_values() -> None:
+    long_str = "x" * 300
+    result = _format_argument(long_str)
+    assert len(result) <= 256
+    assert result.endswith("...")
+
+
+def test_format_argument_short_values_unchanged() -> None:
+    result = _format_argument("hello")
+    assert result == repr("hello")
+
+
+# ---------------------------------------------------------------------------
+# _ensure_schwab_context: MCPContext conversion and invalid-type guard
+# ---------------------------------------------------------------------------
+
+
+class _DummyApprovalManager(ApprovalManager):
+    async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
+        return ApprovalDecision.APPROVED
+
+
+def _make_request_context() -> Any:
+    lifespan_context = SchwabServerContext(
+        client=cast(AsyncClient, object()),
+        approval_manager=_DummyApprovalManager(),
+    )
+    return SimpleNamespace(
+        lifespan_context=lifespan_context,
+        request_id="test-req",
+        meta=None,
+        session=SimpleNamespace(send_log_message=lambda **_: None),
+    )
+
+
+def test_ensure_schwab_context_converts_mcp_context() -> None:
+    """An MCPContext argument is transparently converted to SchwabContext."""
+    request_context = _make_request_context()
+
+    received: list[Any] = []
+
+    async def tool(ctx: SchwabContext) -> str:
+        received.append(ctx)
+        return "ok"
+
+    wrapped = _registration._ensure_schwab_context(tool)
+
+    base_ctx = MCPContext.model_construct(
+        _request_context=cast(Any, request_context),
+        _fastmcp=None,
+    )
+
+    async def runner() -> str:
+        return await wrapped(base_ctx)
+
+    asyncio.run(runner())
+    assert len(received) == 1
+    assert isinstance(received[0], SchwabContext)
+
+
+def test_ensure_schwab_context_rejects_invalid_type() -> None:
+    """A non-context argument raises TypeError."""
+
+    async def tool(ctx: SchwabContext) -> str:
+        return "ok"
+
+    wrapped = _registration._ensure_schwab_context(tool)
+
+    async def runner() -> None:
+        await wrapped("not-a-context")  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError, match="must be an MCP context"):
+        asyncio.run(runner())
+
+
+def test_ensure_schwab_context_handles_sync_result() -> None:
+    """Works when the wrapped function returns a non-awaitable synchronously."""
+
+    def sync_tool(ctx: SchwabContext) -> str:  # type: ignore[return-value]
+        return "sync"
+
+    wrapped = _registration._ensure_schwab_context(sync_tool)  # type: ignore[arg-type]
+    request_context = _make_request_context()
+    ctx = SchwabContext.model_construct(
+        _request_context=cast(Any, request_context),
+        _fastmcp=None,
+    )
+
+    async def runner() -> Any:
+        return await wrapped(ctx)
+
+    result = asyncio.run(runner())
+    assert result == "sync"
+
+
+# ---------------------------------------------------------------------------
+# register_tool: annotation backfill from partial ToolAnnotations
+# ---------------------------------------------------------------------------
+
+
+async def _noop_tool(ctx: SchwabContext) -> str:  # noqa: ARG001
+    """noop"""
+    return "ok"
+
+
+def test_register_tool_fills_readonly_hint_when_missing() -> None:
+    """readOnlyHint=None in caller-supplied annotations is filled based on write flag."""
+    server = FastMCP(name="hint-test")
+    partial_annotations = ToolAnnotations(readOnlyHint=None, destructiveHint=None)
+    register_tool(server, _noop_tool, annotations=partial_annotations)
+
+    tool = _tool_by_name(server, "_noop_tool")
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True  # non-write tool → True
+
+
+def test_register_tool_fills_destructive_hint_for_write_tools() -> None:
+    """destructiveHint=None is filled to True for write tools."""
+    server = FastMCP(name="destructive-test")
+    partial_annotations = ToolAnnotations(readOnlyHint=False, destructiveHint=None)
+    register_tool(server, _noop_tool, write=True, annotations=partial_annotations)
+
+    tool = _tool_by_name(server, "_noop_tool")
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is False
+    assert tool.annotations.destructiveHint is True
+
+
+def test_register_tool_preserves_explicit_annotation_values() -> None:
+    """Explicitly set annotation values are not overwritten."""
+    server = FastMCP(name="explicit-test")
+    explicit_annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
+    register_tool(server, _noop_tool, write=True, annotations=explicit_annotations)
+
+    tool = _tool_by_name(server, "_noop_tool")
+    assert tool.annotations is not None
+    assert tool.annotations.readOnlyHint is True
+    assert tool.annotations.destructiveHint is False
+
+
+# ---------------------------------------------------------------------------
+# Forward-ref globals: integration test that covers globals-copy call sites
+# ---------------------------------------------------------------------------
+
+
+def test_wrapped_tool_resolves_forward_ref_annotations() -> None:
+    """A tool using forward-ref annotations from its own module executes without NameError."""
+
+    # Define a tool at module scope so its __module__ resolves correctly,
+    # then register it through the full stack (ensure + wrap + result_transform).
+    # All three wrappers copy the originating module's globals into the wrapper,
+    # ensuring forward-ref annotations remain resolvable.
+
+    async def annotated_tool(ctx: "SchwabContext") -> "str":  # noqa: F821
+        return "forward-ref-ok"
+
+    annotated_tool.__module__ = __name__
+
+    server = FastMCP(name="fwd-ref")
+    register_tool(server, annotated_tool, result_transform=lambda v: v)
+
+    tool = _tool_by_name(server, "annotated_tool")
+
+    request_context = _make_request_context()
+    ctx = SchwabContext.model_construct(
+        _request_context=cast(Any, request_context),
+        _fastmcp=None,
+    )
+
+    result = asyncio.run(tool.fn(ctx))
+    assert result == "forward-ref-ok"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,14 @@
 import asyncio
+import io
+import json
 import logging
-from typing import cast
+import sys
+from typing import Any, cast
 
+import pytest
 from schwab.client import AsyncClient
 from schwab_mcp.context import SchwabServerContext
-from schwab_mcp.server import SchwabMCPServer
+from schwab_mcp.server import SchwabMCPServer, send_error_response
 from schwab_mcp.approvals import ApprovalDecision, ApprovalManager, ApprovalRequest
 
 
@@ -93,3 +97,147 @@ def test_server_logs_errors_when_closing_client(caplog) -> None:
     assert "Failed to close Schwab async client session during shutdown." in caplog.text
     assert approval_manager.started is True
     assert approval_manager.stopped is True
+
+
+def test_lifespan_logs_error_when_approval_manager_stop_raises(caplog) -> None:
+    class FailingApprovalManager(ApprovalManager):
+        def __init__(self) -> None:
+            self.started = False
+
+        async def start(self) -> None:
+            self.started = True
+
+        async def stop(self) -> None:
+            raise RuntimeError("approval manager stop boom")
+
+        async def require(self, request: ApprovalRequest) -> ApprovalDecision:  # noqa: ARG002
+            return ApprovalDecision.APPROVED
+
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
+    failing_approval = FailingApprovalManager()
+    server = SchwabMCPServer(
+        "schwab-mcp",
+        client,
+        approval_manager=failing_approval,
+        allow_write=False,
+    )
+
+    lifespan_factory = server._server.settings.lifespan
+    assert callable(lifespan_factory)
+
+    async def runner() -> None:
+        async with lifespan_factory(server._server):
+            pass
+
+    with caplog.at_level(logging.ERROR):
+        asyncio.run(runner())
+
+    assert failing_approval.started is True
+    assert "Failed to shut down approval manager cleanly." in caplog.text
+    # Client session close still runs after approval manager failure
+    assert dummy_client.closed is True
+
+
+def test_toon_transform_returns_string_payload_unchanged(monkeypatch) -> None:
+    """When use_json=False, the toon transform must pass string payloads through."""
+    captured_transform: dict[str, Any] = {}
+
+    import schwab_mcp.server as server_module
+
+    def capturing_register(mcp_server, client, *, result_transform, **kwargs):
+        captured_transform["fn"] = result_transform
+        # Don't call original — we just want the transform function
+
+    monkeypatch.setattr(server_module, "register_tools", capturing_register)
+    monkeypatch.setattr(server_module, "register_resources", lambda *a, **kw: None)
+
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
+    approval_manager = DummyApprovalManager()
+
+    SchwabMCPServer(
+        "schwab-mcp",
+        client,
+        approval_manager=approval_manager,
+        allow_write=False,
+        use_json=False,
+    )
+
+    transform = captured_transform["fn"]
+    assert transform is not None
+    assert transform("already a string") == "already a string"
+    # Non-string payload goes through toon encoding (must return a string)
+    result = transform({"key": "value"})
+    assert isinstance(result, str)
+
+
+def test_json_strip_transform_returns_string_payload_unchanged(monkeypatch) -> None:
+    """When use_json=True, the strip transform must pass string payloads through."""
+    captured_transform: dict[str, Any] = {}
+
+    import schwab_mcp.server as server_module
+
+    def capturing_register(mcp_server, client, *, result_transform, **kwargs):
+        captured_transform["fn"] = result_transform
+
+    monkeypatch.setattr(server_module, "register_tools", capturing_register)
+    monkeypatch.setattr(server_module, "register_resources", lambda *a, **kw: None)
+
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
+    approval_manager = DummyApprovalManager()
+
+    SchwabMCPServer(
+        "schwab-mcp",
+        client,
+        approval_manager=approval_manager,
+        allow_write=False,
+        use_json=True,
+    )
+
+    transform = captured_transform["fn"]
+    assert transform is not None
+    assert transform("already a string") == "already a string"
+    # Non-string payload is passed through strip_noise and returned as-is (dict)
+    result = transform({"key": "value"})
+    assert isinstance(result, dict)
+
+
+@pytest.mark.anyio
+async def test_server_run_calls_run_stdio_async(monkeypatch) -> None:
+    """server.run() must delegate to FastMCP's run_stdio_async."""
+    called: dict[str, bool] = {}
+
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
+    approval_manager = DummyApprovalManager()
+    server = SchwabMCPServer(
+        "schwab-mcp",
+        client,
+        approval_manager=approval_manager,
+        allow_write=False,
+    )
+
+    async def fake_run_stdio_async() -> None:
+        called["run"] = True
+
+    monkeypatch.setattr(server._server, "run_stdio_async", fake_run_stdio_async)
+    await server.run()
+    assert called.get("run") is True
+
+
+def test_send_error_response_defaults_details_to_empty_dict(monkeypatch) -> None:
+    """send_error_response without details= uses an empty dict, not None."""
+    buf = io.StringIO()
+    monkeypatch.setattr(sys, "stdout", buf)
+
+    with pytest.raises(SystemExit) as exc_info:
+        send_error_response("something went wrong", code=401)
+
+    assert exc_info.value.code == 1
+    payload = json.loads(buf.getvalue().strip())
+    assert payload["error"]["code"] == 401
+    assert payload["error"]["message"] == "something went wrong"
+    # data should be an empty dict, not null
+    assert payload["error"]["data"] == {}

--- a/tests/test_technical_tools.py
+++ b/tests/test_technical_tools.py
@@ -859,3 +859,821 @@ def test_pivot_points_defaults_to_default_points_not_lookback(
 
     values = result["values"]
     assert len(values) == base.DEFAULT_POINTS
+
+
+# ---------------------------------------------------------------------------
+# base.py — normalize_interval
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_interval_rejects_unknown_interval():
+    with pytest.raises(ValueError, match="Unsupported interval"):
+        base.normalize_interval("2h")
+
+
+def test_normalize_interval_accepts_valid_intervals():
+    for iv in ("1m", "5m", "10m", "15m", "30m", "1d", "1w"):
+        assert base.normalize_interval(iv) == iv
+
+
+# ---------------------------------------------------------------------------
+# base.py — series_to_json edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_series_to_json_returns_empty_for_empty_series():
+    assert base.series_to_json(pd.Series([], dtype=float)) == []
+
+
+def test_series_to_json_returns_empty_after_dropna():
+    s = pd.Series(
+        [float("nan")], index=pd.date_range("2024-01-01", periods=1, tz="UTC")
+    )
+    assert base.series_to_json(s) == []
+
+
+def test_series_to_json_uses_series_name_when_no_value_key():
+    index = pd.date_range("2024-01-01", periods=2, tz="UTC")
+    s = pd.Series([1.0, 2.0], index=index, name="my_col")
+    rows = base.series_to_json(s)
+    assert rows[-1]["my_col"] == pytest.approx(2.0)
+
+
+def test_series_to_json_uses_value_fallback_name_when_no_name():
+    index = pd.date_range("2024-01-01", periods=2, tz="UTC")
+    s = pd.Series([1.0, 2.0], index=index)  # name=None
+    rows = base.series_to_json(s)
+    assert "value" in rows[-1]
+
+
+def test_series_to_json_with_limit_none_returns_all_rows():
+    index = pd.date_range("2024-01-01", periods=5, tz="UTC")
+    s = pd.Series(range(5, 10), index=index, dtype=float)
+    rows = base.series_to_json(s, limit=None, value_key="v")
+    assert len(rows) == 5
+
+
+def test_series_to_json_non_datetime_index_is_normalized():
+    # String index → converted via pd.to_datetime path (covers non-DatetimeIndex branch)
+    index = pd.Index(["2024-01-01", "2024-01-02"])
+    s = pd.Series([10.0, 20.0], index=index)
+    rows = base.series_to_json(s, value_key="x")
+    assert len(rows) == 2
+
+
+# ---------------------------------------------------------------------------
+# base.py — frame_to_json edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_frame_to_json_returns_empty_for_empty_frame():
+    assert base.frame_to_json(pd.DataFrame()) == []
+
+
+def test_frame_to_json_returns_empty_when_all_non_numeric():
+    index = pd.date_range("2024-01-01", periods=2, tz="UTC")
+    frame = pd.DataFrame({"col": ["a", "b"]}, index=index)
+    assert base.frame_to_json(frame) == []
+
+
+def test_frame_to_json_with_limit_none_returns_all_rows():
+    index = pd.date_range("2024-01-01", periods=4, tz="UTC")
+    frame = pd.DataFrame({"v": [1.0, 2.0, 3.0, 4.0]}, index=index)
+    rows = base.frame_to_json(frame, limit=None)
+    assert len(rows) == 4
+
+
+# ---------------------------------------------------------------------------
+# base.py — compute_series_indicator error branches
+# ---------------------------------------------------------------------------
+
+
+def test_compute_series_indicator_raises_on_empty_frame(monkeypatch, dummy_ctx):
+    async def fake_fetch(ctx, symbol, **kwargs):
+        meta = {
+            "symbol": symbol,
+            "interval": "1d",
+            "start": None,
+            "end": "2024-01-06T00:00:00+00:00",
+            "bars_requested": None,
+            "empty": True,
+            "candles_returned": 0,
+        }
+        return pd.DataFrame(), meta
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="No price data"):
+        run(
+            base.compute_series_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: None,
+                indicator_name="test",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+                value_key="v",
+                required_columns=(),  # skip column check so empty-frame branch fires
+            )
+        )
+
+
+def test_compute_series_indicator_raises_when_fn_returns_none(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(RuntimeError, match="returned no values"):
+        run(
+            base.compute_series_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: None,
+                indicator_name="bad_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+                value_key="v",
+            )
+        )
+
+
+def test_compute_series_indicator_raises_when_fn_returns_dataframe(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(TypeError, match="got DataFrame"):
+        run(
+            base.compute_series_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: pd.DataFrame({"a": f["close"]}),
+                indicator_name="bad_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+                value_key="v",
+            )
+        )
+
+
+def test_compute_series_indicator_raises_when_result_all_nan(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="Not enough price history"):
+        run(
+            base.compute_series_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: pd.Series(
+                    [float("nan")] * len(f), index=f.index
+                ),
+                indicator_name="all_nan_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+                value_key="v",
+            )
+        )
+
+
+def test_compute_series_indicator_includes_extra_metadata(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run(
+        base.compute_series_indicator(
+            dummy_ctx,
+            "HOOD",
+            indicator_fn=lambda f: f["close"],
+            indicator_name="close",
+            interval="1d",
+            start=None,
+            end=None,
+            bars=10,
+            points=3,
+            value_key="close",
+            extra_metadata={"foo": "bar"},
+        )
+    )
+    assert isinstance(result, dict)
+    assert result["foo"] == "bar"
+
+
+# ---------------------------------------------------------------------------
+# base.py — compute_frame_indicator error branches
+# ---------------------------------------------------------------------------
+
+
+def test_compute_frame_indicator_raises_on_empty_frame(monkeypatch, dummy_ctx):
+    async def fake_fetch(ctx, symbol, **kwargs):
+        meta = {
+            "symbol": symbol,
+            "interval": "1d",
+            "start": None,
+            "end": "2024-01-06T00:00:00+00:00",
+            "bars_requested": None,
+            "empty": True,
+            "candles_returned": 0,
+        }
+        return pd.DataFrame(), meta
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="No price data"):
+        run(
+            base.compute_frame_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: None,
+                indicator_name="test",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+                required_columns=(),  # skip column check so empty-frame branch fires
+            )
+        )
+
+
+def test_compute_frame_indicator_raises_when_fn_returns_none(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(RuntimeError, match="returned no values"):
+        run(
+            base.compute_frame_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: None,
+                indicator_name="bad_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+            )
+        )
+
+
+def test_compute_frame_indicator_raises_when_fn_returns_series(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(TypeError, match="got Series"):
+        run(
+            base.compute_frame_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: f["close"],
+                indicator_name="bad_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+            )
+        )
+
+
+def test_compute_frame_indicator_raises_when_result_all_nan(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="Not enough price history"):
+        run(
+            base.compute_frame_indicator(
+                dummy_ctx,
+                "HOOD",
+                indicator_fn=lambda f: pd.DataFrame(
+                    {"a": [float("nan")] * len(f)}, index=f.index
+                ),
+                indicator_name="all_nan_ind",
+                interval="1d",
+                start=None,
+                end=None,
+                bars=10,
+                points=3,
+            )
+        )
+
+
+def test_compute_frame_indicator_includes_extra_metadata(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run(
+        base.compute_frame_indicator(
+            dummy_ctx,
+            "HOOD",
+            indicator_fn=lambda f: pd.DataFrame({"a": f["close"]}, index=f.index),
+            indicator_name="test",
+            interval="1d",
+            start=None,
+            end=None,
+            bars=10,
+            points=3,
+            extra_metadata={"baz": 42},
+        )
+    )
+    assert isinstance(result, dict)
+    assert result["baz"] == 42
+
+
+# ---------------------------------------------------------------------------
+# overlays.py — additional pivot methods
+# ---------------------------------------------------------------------------
+
+
+def test_pivot_points_fibonacci_returns_levels(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(overlays.pivot_points(dummy_ctx, "HOOD", method="fibonacci"))
+
+    values = result["values"]
+    assert len(values) > 0
+    assert {"PP", "R1", "S1", "R2", "S2", "R3", "S3"}.issubset(values[-1].keys())
+
+
+def test_pivot_points_camarilla_returns_r4_and_s4(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(overlays.pivot_points(dummy_ctx, "HOOD", method="camarilla"))
+
+    values = result["values"]
+    assert len(values) > 0
+    assert {"PP", "R1", "S1", "R2", "S2", "R3", "S3", "R4", "S4"}.issubset(
+        values[-1].keys()
+    )
+
+
+def test_pivot_points_woodie_returns_levels(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(overlays.pivot_points(dummy_ctx, "HOOD", method="woodie"))
+
+    values = result["values"]
+    assert len(values) > 0
+    assert {"PP", "R1", "S1", "R2", "S2"}.issubset(values[-1].keys())
+
+
+def test_pivot_points_demark_with_open_column(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(base, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(overlays.pivot_points(dummy_ctx, "HOOD", method="demark"))
+
+    values = result["values"]
+    assert len(values) > 0
+    assert {"PP", "R1", "S1"}.issubset(values[-1].keys())
+
+
+def test_pivot_points_rejects_non_positive_lookback(dummy_ctx):
+    with pytest.raises(ValueError, match="lookback must be positive"):
+        run(overlays.pivot_points(dummy_ctx, "HOOD", lookback=0))
+
+
+def test_vwap_rejects_non_positive_length(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(overlays, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="length must be positive"):
+        run(overlays.vwap(dummy_ctx, "HOOD", length=0))
+
+
+def test_vwap_raises_when_pandas_ta_returns_none(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(overlays, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        overlays,
+        "pandas_ta",
+        SimpleNamespace(
+            vwap=lambda *args, **kwargs: None,
+            pivot_points=None,
+            bbands=None,
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="returned no values"):
+        run(overlays.vwap(dummy_ctx, "HOOD"))
+
+
+def test_vwap_raises_when_result_all_nan(monkeypatch, dummy_ctx, ohlcv_data):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(overlays, "fetch_price_frame", fake_fetch)
+    monkeypatch.setattr(
+        overlays,
+        "pandas_ta",
+        SimpleNamespace(
+            vwap=lambda high, low, close, volume, **kw: pd.Series(
+                [float("nan")] * len(close), index=close.index
+            ),
+            pivot_points=None,
+            bbands=None,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Not enough price history"):
+        run(overlays.vwap(dummy_ctx, "HOOD"))
+
+
+def test_bollinger_bands_rejects_length_lte_one(dummy_ctx):
+    with pytest.raises(ValueError, match="greater than 1"):
+        run(overlays.bollinger_bands(dummy_ctx, "HOOD", length=1))
+
+
+def test_bollinger_bands_rejects_non_positive_std_dev(dummy_ctx):
+    with pytest.raises(ValueError, match="std_dev must be positive"):
+        run(overlays.bollinger_bands(dummy_ctx, "HOOD", std_dev=0.0))
+
+
+# ---------------------------------------------------------------------------
+# trend.py — validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_macd_rejects_non_positive_lengths(dummy_ctx):
+    with pytest.raises(ValueError, match="must be positive"):
+        run(trend.macd(dummy_ctx, "HOOD", fast_length=0, slow_length=26))
+
+
+def test_macd_rejects_fast_gte_slow(dummy_ctx):
+    with pytest.raises(ValueError, match="fast_length must be less"):
+        run(trend.macd(dummy_ctx, "HOOD", fast_length=26, slow_length=12))
+
+
+def test_atr_rejects_non_positive_length(dummy_ctx):
+    with pytest.raises(ValueError, match="length must be a positive integer"):
+        run(trend.atr(dummy_ctx, "HOOD", length=0))
+
+
+def test_adx_rejects_non_positive_length(dummy_ctx):
+    with pytest.raises(ValueError, match="length must be a positive integer"):
+        run(trend.adx(dummy_ctx, "HOOD", length=0))
+
+
+# ---------------------------------------------------------------------------
+# volatility.py — _volatility_regime branches
+# ---------------------------------------------------------------------------
+
+
+def test_volatility_regime_very_low():
+    assert volatility._volatility_regime(5.0) == "very_low"
+
+
+def test_volatility_regime_low():
+    assert volatility._volatility_regime(12.0) == "low"
+
+
+def test_volatility_regime_normal():
+    assert volatility._volatility_regime(17.0) == "normal"
+
+
+def test_volatility_regime_elevated():
+    assert volatility._volatility_regime(25.0) == "elevated"
+
+
+def test_volatility_regime_high():
+    assert volatility._volatility_regime(40.0) == "high"
+
+
+def test_volatility_regime_extreme():
+    assert volatility._volatility_regime(60.0) == "extreme"
+
+
+def test_compute_percentile_returns_50_for_empty_series():
+    assert volatility._compute_percentile(pd.Series([], dtype=float), 0.1) == 50.0
+
+
+# ---------------------------------------------------------------------------
+# volatility.py — historical_volatility validation
+# ---------------------------------------------------------------------------
+
+
+def test_historical_volatility_rejects_period_lte_one(dummy_ctx):
+    with pytest.raises(ValueError, match="period must be greater than 1"):
+        run(volatility.historical_volatility(dummy_ctx, "HOOD", period=1))
+
+
+def test_historical_volatility_rejects_non_positive_annualize_factor(dummy_ctx):
+    with pytest.raises(ValueError, match="annualize_factor must be positive"):
+        run(volatility.historical_volatility(dummy_ctx, "HOOD", annualize_factor=0))
+
+
+def test_historical_volatility_rejects_invalid_method(dummy_ctx):
+    with pytest.raises(ValueError, match="Invalid method"):
+        run(volatility.historical_volatility(dummy_ctx, "HOOD", method="bogus"))
+
+
+def test_historical_volatility_raises_on_empty_frame(monkeypatch, dummy_ctx):
+    async def fake_fetch(ctx, symbol, **kwargs):
+        meta = {
+            "symbol": symbol,
+            "interval": "1d",
+            "start": None,
+            "end": "2024-01-01T00:00:00+00:00",
+            "bars_requested": None,
+            "empty": True,
+            "candles_returned": 0,
+        }
+        return pd.DataFrame(), meta
+
+    monkeypatch.setattr(volatility, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="no data"):
+        run(volatility.historical_volatility(dummy_ctx, "HOOD", period=5))
+
+
+def test_historical_volatility_parkinson_raises_on_insufficient_data(
+    monkeypatch, dummy_ctx, ohlcv_data
+):
+    frame, metadata = ohlcv_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame.iloc[:1], metadata
+
+    monkeypatch.setattr(volatility, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="Not enough high/low"):
+        run(
+            volatility.historical_volatility(
+                dummy_ctx, "HOOD", period=3, method="parkinson"
+            )
+        )
+
+
+def test_historical_volatility_log_returns_method(monkeypatch, dummy_ctx, price_data):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        return frame, metadata
+
+    monkeypatch.setattr(volatility, "fetch_price_frame", fake_fetch)
+
+    result = run_tool(
+        volatility.historical_volatility(
+            dummy_ctx, "HOOD", period=3, method="log_returns"
+        )
+    )
+
+    assert result["method"] == "log_returns"
+    assert result["daily_vol"] > 0
+    assert result["annualized_vol"] > 0
+
+
+def test_historical_volatility_close_to_close_raises_on_insufficient_returns(
+    monkeypatch, dummy_ctx, price_data
+):
+    frame, metadata = price_data
+
+    async def fake_fetch(ctx, symbol, **kwargs):
+        # Only 2 rows → 1 return value, not enough for period=3
+        return frame.iloc[:2], metadata
+
+    monkeypatch.setattr(volatility, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError):
+        run(
+            volatility.historical_volatility(
+                dummy_ctx, "HOOD", period=3, method="close_to_close"
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
+# volatility.py — expected_move error paths
+# ---------------------------------------------------------------------------
+
+
+def test_expected_move_raises_on_non_positive_put_price(dummy_ctx):
+    with pytest.raises(ValueError, match="put_price must be a positive"):
+        run(
+            volatility.expected_move(
+                dummy_ctx,
+                "HOOD",
+                call_price=1.0,
+                put_price=-0.5,
+                underlying_price=100.0,
+            )
+        )
+
+
+def test_expected_move_raises_when_underlying_is_zero(monkeypatch, dummy_ctx):
+    async def fake_fetch(ctx, symbol, **kwargs):
+        index = pd.date_range("2024-01-01", periods=1, tz="UTC")
+        frame = pd.DataFrame({"close": [0.0]}, index=index)
+        meta = {
+            "symbol": symbol,
+            "interval": "1d",
+            "start": None,
+            "end": "2024-01-01T00:00:00+00:00",
+            "bars_requested": None,
+            "empty": False,
+            "candles_returned": 1,
+        }
+        return frame, meta
+
+    async def fake_call(func, *args, **kwargs):
+        # Return chain with no underlyingPrice so underlying falls back to price history
+        return {"callExpDateMap": {}, "putExpDateMap": {}}
+
+    monkeypatch.setattr(volatility, "call", fake_call)
+    monkeypatch.setattr(volatility, "fetch_price_frame", fake_fetch)
+
+    with pytest.raises(ValueError, match="underlying_price must be positive"):
+        run(volatility.expected_move(dummy_ctx, "HOOD"))
+
+
+def test_expected_move_raises_when_no_atm_contracts(monkeypatch, dummy_ctx):
+    async def fake_call(func, *args, **kwargs):
+        return {
+            "underlyingPrice": 100.0,
+            "callExpDateMap": {},
+            "putExpDateMap": {},
+        }
+
+    async def fail_fetch(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("should not fetch price history")
+
+    monkeypatch.setattr(volatility, "call", fake_call)
+    monkeypatch.setattr(volatility, "fetch_price_frame", fail_fetch)
+
+    with pytest.raises(ValueError, match="Unable to locate at-the-money"):
+        run(volatility.expected_move(dummy_ctx, "HOOD"))
+
+
+def test_expected_move_raises_when_chain_response_bad_type(monkeypatch, dummy_ctx):
+    async def fake_call(func, *args, **kwargs):
+        return "not-a-mapping"
+
+    monkeypatch.setattr(volatility, "call", fake_call)
+
+    with pytest.raises(TypeError, match="Unexpected option chain response"):
+        run(volatility.expected_move(dummy_ctx, "HOOD"))
+
+
+def test_expected_move_selects_closer_strike_when_multiple(monkeypatch, dummy_ctx):
+    """_select_atm_contracts picks the strike nearest the underlying price."""
+    chain_payload = {
+        "underlyingPrice": 100.0,
+        "callExpDateMap": {
+            "2024-11-15:28": {
+                "99.0": [{"mark": 2.0}],
+                "110.0": [{"mark": 0.5}],
+            }
+        },
+        "putExpDateMap": {
+            "2024-11-15:28": {
+                "99.0": [{"mark": 1.8}],
+                "110.0": [{"mark": 0.4}],
+            }
+        },
+    }
+
+    async def fake_call(func, *args, **kwargs):
+        return chain_payload
+
+    async def fail_fetch(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("should not fetch price history")
+
+    monkeypatch.setattr(volatility, "call", fake_call)
+    monkeypatch.setattr(volatility, "fetch_price_frame", fail_fetch)
+
+    result = run_tool(volatility.expected_move(dummy_ctx, "HOOD"))
+
+    # 99 is closer to 100 than 110, so mark=2.0 call and 1.8 put are selected
+    assert result["call_price"] == pytest.approx(2.0)
+    assert result["put_price"] == pytest.approx(1.8)
+
+
+def test_option_price_falls_back_to_last_price():
+    """_option_price uses last/lastPrice/closePrice when mark/bid+ask absent."""
+    contract = {"last": 1.75}
+    assert volatility._option_price(contract) == pytest.approx(1.75)
+
+
+def test_option_price_raises_when_no_price_available():
+    with pytest.raises(ValueError, match="missing price information"):
+        volatility._option_price({})
+
+
+def test_is_positive_number_returns_false_for_bad_value():
+    assert volatility._is_positive_number("not-a-number") is False
+    assert volatility._is_positive_number(None) is False
+    assert volatility._is_positive_number(-1.0) is False
+
+
+def test_expected_move_raises_when_atm_strike_has_no_matching_put(
+    monkeypatch, dummy_ctx
+):
+    """Calls exist but no matching put for any expiry key → ValueError."""
+    chain_payload = {
+        "underlyingPrice": 100.0,
+        "callExpDateMap": {
+            "2024-11-15:28": {
+                "100.0": [{"mark": 2.0}],
+            }
+        },
+        "putExpDateMap": {},  # no expiry key at all
+    }
+
+    async def fake_call(func, *args, **kwargs):
+        return chain_payload
+
+    async def fail_fetch(*args, **kwargs):  # pragma: no cover
+        raise AssertionError("should not fetch price history")
+
+    monkeypatch.setattr(volatility, "call", fake_call)
+    monkeypatch.setattr(volatility, "fetch_price_frame", fail_fetch)
+
+    with pytest.raises(ValueError, match="Unable to locate at-the-money"):
+        run(volatility.expected_move(dummy_ctx, "HOOD"))


### PR DESCRIPTION
## What

Coverage sat at 74% with several modules barely touched: `auth.py` (8%), `approvals/discord.py` (18%), and the `tools/technical` indicator wrappers (55-78%). Most of those gaps were real untested logic — OAuth login flow, Discord reaction handling, indicator validation branches — not just missing boilerplate, so they were worth closing.

This adds tests for those modules plus the smaller remaining edge cases in `tools/_registration.py`, `server.py`, and `cli.py`:

- `auth.py`: `easy_client`'s fresh-token-reuse vs stale-token-triggers-login branches, and `client_from_login_flow`'s hostname validation, timeout, and happy-path redirect handling. Mocks multiprocessing, httpx, and webbrowser so nothing spawns a real subprocess or browser.
- `approvals/discord.py`: the approval manager's start/stop lifecycle, channel resolution, `require()` outcomes (approved, denied, timed out, HTTPException), and reaction-based authorization. Tests call the manager's handler methods directly rather than going through the thin `discord.Client` event delegation.
- `tools/technical/{base,overlays,trend,volatility}.py`: parameter validation, empty/insufficient-data handling, and indicator edge cases that the existing fixture-based test file didn't exercise yet.
- `tools/_registration.py`: the approval-wrapping error paths, keepalive task lifecycle, and annotation-resolution helpers, including one integration-style test that exercises the forward-ref/globals handling end to end instead of poking at internals.
- `server.py` / `cli.py`: the remaining error-exit paths in the `server` command (missing credentials, stale token, bad Discord config) and a couple of transform/lifecycle branches in the server module.

Also excludes `tools/_protocols.py` from the coverage report — it's pure `Protocol` declarations with no runtime behavior, and its permanent 0% was skewing the overall number.

`tools/orders.py`, `quotes.py`, `account.py`, and a few other already-solid modules were left alone; this only touches modules that had a real gap.

## Testing

- `uv run ruff check .`
- `uv run pyright`
- `uv run vulture`
- `uv run pytest` (587 passed, up from 446)
- Coverage: 74% -> 92% overall (auth.py 71%, discord.py 91%, `_registration.py` 96%, `server.py` 100%, `cli.py` 95%, technical overlays/trend 100%)
