### PR TITLE
chore(lint): adopt bandit, builtins, simplify rules, and pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.1
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pyright>=1.1.407",
     "pytest>=8.4.2",
     "pytest-cov>=6.0.0",
+    "pytest-randomly>=3.16",
     "ruff>=0.14.0",
     "vulture>=2.14",
 ]
@@ -66,25 +67,28 @@ target-version = "py310"
 
 [tool.ruff.lint]
 select = [
-    "F",      # Pyflakes
-    "E",      # pycodestyle (Error)
-    "I",      # isort
-    "D",      # pydocstyle
-    "UP",     # pyupgrade
-    "YTT",    # flake8-2020
+    "A",      # flake8-builtins
     "B",      # flake8-bugbear
-    "T10",    # flake8-debugger
-    "T20",    # flake8-print
     "C4",     # flake8-comprehensions
+    "D",      # pydocstyle
+    "E",      # pycodestyle (Error)
+    "F",      # Pyflakes
+    "I",      # isort
     "PERF",   # Perflint
     "PIE",    # flake8-pie
+    "S",      # flake8-bandit
+    "SIM",    # flake8-simplify
+    "T10",    # flake8-debugger
+    "T20",    # flake8-print
+    "UP",     # pyupgrade
+    "YTT",    # flake8-2020
 ]
 ignore = ["D105", "D107", "D205", "D415", "E501", "B011", "B028", "B904", "PIE804"]
 isort = { known-first-party = ["schwab_mcp", "tests"], combine-as-imports = true }
 pydocstyle = { convention = "google" }
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["D", "B", "C4", "T", "E721", "F811"]
+"tests/**/*.py" = ["A002", "D", "B", "C4", "T", "E721", "F811", "S101", "S105", "S106", "S108"]
 "src/schwab_mcp/auth.py" = ["T201"]
 
 [tool.ruff.format]

--- a/src/schwab_mcp/auth.py
+++ b/src/schwab_mcp/auth.py
@@ -134,10 +134,9 @@ def client_from_login_flow(
         try:
             yield
         finally:
-            try:
-                auth.psutil.Process(server.pid).kill()
-            except auth.psutil.NoSuchProcess:
-                pass
+            if server.pid is not None:
+                with auth.contextlib.suppress(auth.psutil.NoSuchProcess):
+                    auth.psutil.Process(server.pid).kill()
 
     with callback_server():
         # Wait until the server successfully starts
@@ -200,11 +199,9 @@ def client_from_login_flow(
             print("***********************************************************************")
             print()
 
-        try:
+        with auth.contextlib.suppress(Exception):
             controller = auth.webbrowser.get(requested_browser)
             controller.open(auth_context.authorization_url)
-        except Exception:
-            pass
 
         # Wait for a response
         now = auth.__TIME_TIME()
@@ -217,7 +214,7 @@ def client_from_login_flow(
                     # XXX: We're detecting a test environment here to avoid an
                     #      infinite sleep. Surely there must be a better way to do
                     #      this...
-                    if auth.__TIME_TIME != auth.time.time:  # pragma: no cover
+                    if auth.time.time != auth.__TIME_TIME:  # pragma: no cover
                         raise ValueError("endless wait requested")
                 else:
                     break

--- a/src/schwab_mcp/tools/technical/volatility.py
+++ b/src/schwab_mcp/tools/technical/volatility.py
@@ -123,10 +123,7 @@ async def historical_volatility(
         if len(closes) < required_points:
             raise ValueError("Not enough closing prices to compute historical volatility for the requested period.")
 
-        if method_key == "log_returns":
-            returns = np.log(closes / closes.shift(1))
-        else:
-            returns = closes.pct_change()
+        returns = np.log(closes / closes.shift(1)) if method_key == "log_returns" else closes.pct_change()
 
         returns = returns.dropna()
         if len(returns) < period:

--- a/tests/test_discord_approvals.py
+++ b/tests/test_discord_approvals.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -123,9 +124,11 @@ def inject_pending(mgr: DiscordApprovalManager, msg: Any) -> asyncio.Future[Appr
 
 
 def test_requires_at_least_one_approver_id() -> None:
-    with pytest.raises(ValueError, match="at least one approver ID"):
-        with patch("schwab_mcp.approvals.discord._ApprovalClient"):
-            DiscordApprovalManager(make_settings(approver_ids=frozenset()))
+    with (
+        pytest.raises(ValueError, match="at least one approver ID"),
+        patch("schwab_mcp.approvals.discord._ApprovalClient"),
+    ):
+        DiscordApprovalManager(make_settings(approver_ids=frozenset()))
 
 
 # ---------------------------------------------------------------------------
@@ -150,10 +153,8 @@ async def test_start_launches_runner_task_and_waits_for_ready() -> None:
     # Clean up
     runner = mgr._runner
     runner.cancel()
-    try:
+    with contextlib.suppress(asyncio.CancelledError):
         await runner
-    except (asyncio.CancelledError, Exception):
-        pass
 
 
 @pytest.mark.anyio
@@ -175,10 +176,8 @@ async def test_start_is_idempotent() -> None:
     runner = mgr._runner
     if runner is not None:
         runner.cancel()
-        try:
+        with contextlib.suppress(asyncio.CancelledError):
             await runner
-        except (asyncio.CancelledError, Exception):
-            pass
 
 
 @pytest.mark.anyio

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -1469,7 +1469,7 @@ class TestPruneOrderTypeGuards:
         }
         result = orders._prune_order(order)
         assert isinstance(result, dict)
-        assert "legs" not in result.keys()
+        assert "legs" not in result
 
     def test_child_order_strategies_as_dict_not_processed(self):
         """childOrderStrategies that is a dict must not add childOrderStrategies key."""
@@ -1480,7 +1480,7 @@ class TestPruneOrderTypeGuards:
         }
         result = orders._prune_order(order)
         assert isinstance(result, dict)
-        assert "childOrderStrategies" not in result.keys()
+        assert "childOrderStrategies" not in result
 
     def test_empty_order_leg_collection_list_omits_legs_key(self):
         """An empty orderLegCollection list must not add a legs key."""
@@ -1491,7 +1491,7 @@ class TestPruneOrderTypeGuards:
         }
         result = orders._prune_order(order)
         assert isinstance(result, dict)
-        assert "legs" not in result.keys()
+        assert "legs" not in result
 
     def test_all_non_dict_legs_omits_legs_key(self):
         """When all legs are non-dict, the resulting summary is empty, so legs key is omitted."""
@@ -1502,7 +1502,7 @@ class TestPruneOrderTypeGuards:
         }
         result = orders._prune_order(order)
         assert isinstance(result, dict)
-        assert "legs" not in result.keys()
+        assert "legs" not in result
 
     def test_non_dict_order_passes_through(self):
         """Non-dict input to _prune_order must be returned unchanged."""

--- a/uv.lock
+++ b/uv.lock
@@ -1998,6 +1998,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2470,6 +2482,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "ruff" },
     { name = "vulture" },
 ]
@@ -2499,6 +2512,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-randomly", specifier = ">=3.16" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "vulture", specifier = ">=2.14" },
 ]


### PR DESCRIPTION
Picked up a few testing/lint practices from comparing against `okp-mcp` and folded in the ones that made sense for this repo.

Ruff now also runs the bandit (`S`), builtins (`A`), and simplify (`SIM`) rule sets, since we handle OAuth tokens and API secrets and had no security-focused linting at all. Fixed the violations these surfaced: a few bare `try/except: pass` blocks became `contextlib.suppress`, a Yoda condition got flipped, an if/else collapsed into a ternary, and some nested `with` statements and redundant `.keys()` calls in tests got simplified. Also added `pytest-randomly` so the test suite runs in a random order each time, which catches order-dependent test bugs before they bite in CI.

Added a `.pre-commit-config.yaml` with ruff/ruff-format, gitleaks (secret scanning), and the standard toml/yaml/whitespace hygiene hooks. It's opt-in locally for now — CI already runs ruff/pyright/vulture/pytest separately, so this isn't wired into `ci.yml`.

Skipped from the okp-mcp comparison: radon complexity gating, SonarQube, and switching pyright to `ty` — none of those seemed worth the churn here.

## Testing

- `make check` (format-check, lint, typecheck, deadcode, test) — all green, 587 passed
