### PR TITLE
docs: add repository codemap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,3 +234,18 @@ causing oversized responses that exceeded context limits.
 Default from_date to today and to_date to today + 60 days when both
 are omitted. This matches typical option trading horizons.
 ```
+
+## Repository Map
+
+A full codemap is available at `codemap.md` in the project root.
+
+Before working on any task, read `codemap.md` to understand:
+- Project architecture and entry points
+- Directory responsibilities and design patterns
+- Data flow and integration points between modules
+
+For deep work on a specific folder, also read that folder's `codemap.md`.
+
+When changing source code, update the relevant `codemap.md` files if the
+change alters module responsibilities, entry points, control flow,
+integration points, or directory structure.

--- a/codemap.md
+++ b/codemap.md
@@ -1,0 +1,72 @@
+# Repository Atlas: schwab-mcp
+
+## Project Responsibility
+
+`schwab-mcp` is a Python MCP server that exposes Schwab brokerage data,
+market data, option chains, price history, optional technical indicators, and
+approval-gated order workflows to MCP clients. The repository packages a Click
+CLI, Schwab OAuth/token persistence helpers, a FastMCP stdio server, static MCP
+resources, typed request context facades, order preview caching, and Discord
+approval infrastructure for write operations.
+
+## System Entry Points
+
+- `src/schwab_mcp/__init__.py`: package `main()` proxy for the console script.
+- `src/schwab_mcp/cli.py`: Click commands for `auth`, `server`, and
+  `save-credentials`.
+- `src/schwab_mcp/server.py`: `SchwabMCPServer` construction, lifespan wiring,
+  tool/resource registration, result transformation, and stdio serving.
+- `src/schwab_mcp/tools/__init__.py`: MCP tool registration aggregator.
+- `pyproject.toml`: package metadata, dependency groups, console script, and
+  tool configuration.
+- `Containerfile`: container runtime packaging for the MCP server.
+
+## Directory Map
+
+| Directory | Responsibility Summary | Detailed Map |
+|-----------|------------------------|--------------|
+| `src/` | Installable Python source tree containing the Schwab MCP server package and its CLI/runtime modules. | [View Map](src/codemap.md) |
+| `src/schwab_mcp/` | Core application package: CLI, OAuth/token lifecycle, FastMCP server adapter, context model, static resources, and preview cache. | [View Map](src/schwab_mcp/codemap.md) |
+| `src/schwab_mcp/approvals/` | Approval abstraction and Discord-backed approval workflow for Schwab write tools. | [View Map](src/schwab_mcp/approvals/codemap.md) |
+| `src/schwab_mcp/tools/` | MCP tool layer that adapts Schwab API operations, response shaping, order builders, preview/place workflows, and write approvals. | [View Map](src/schwab_mcp/tools/codemap.md) |
+| `src/schwab_mcp/tools/technical/` | Optional technical-analysis tools using Schwab price history and `pandas_ta_classic`/pandas calculations. | [View Map](src/schwab_mcp/tools/technical/codemap.md) |
+
+## Root Assets
+
+- `AGENTS.md`: repository-specific agent instructions, structure, commands,
+  coding style, testing patterns, security notes, and commit format.
+- `README.md`: user-facing setup and usage documentation.
+- `pyproject.toml`: package metadata, dependencies, optional technical-analysis
+  extras, ruff/pyright/pytest configuration, and console script definition.
+- `uv.lock`: locked dependency graph for `uv` installs.
+- `Makefile`: local helper targets for common project workflows.
+- `Containerfile`: container image build recipe.
+- `.pre-commit-config.yaml`: pre-commit hook configuration.
+- `renovate.json`: dependency update automation configuration.
+
+## High-Level Flow
+
+1. Users run the console script, which calls `schwab_mcp.main()` and dispatches
+   to Click command handlers.
+2. Authentication commands resolve credentials, run Schwab OAuth through
+   `schwab-py`, and persist tokens/credentials under the user data directory.
+3. The `server` command creates an async Schwab client, validates token age,
+   configures write-approval behavior, and instantiates `SchwabMCPServer`.
+4. Server startup registers resources and MCP tools. FastMCP lifespan state
+   injects the Schwab client, approval manager, and preview store into each tool
+   call through `SchwabContext`.
+5. Read tools call Schwab endpoints through typed facades and shared response
+   parsing. Write tools either require generic approval wrapping or use the
+   preview-then-place workflow for exact-spec order placement.
+
+## Integration Points
+
+- Schwab integration uses `schwab-py` clients, enums, OAuth helpers, and order
+  builders.
+- MCP integration uses `mcp.server.fastmcp.FastMCP`, FastMCP `Context`, static
+  resources, tool annotations, and stdio transport.
+- Approval integration uses a process-local `ApprovalManager` interface with a
+  Discord implementation for human decisions and a no-op implementation for
+  disabled/bypassed write modes.
+- Optional analytics integration loads `pandas_ta_classic`, pandas, and numpy
+  only when technical tools are enabled and available.

--- a/src/codemap.md
+++ b/src/codemap.md
@@ -1,0 +1,31 @@
+# `src/`
+
+## Responsibility
+
+`src/` contains the installable Python package for the Schwab Model Context Protocol server. Its only application package is `schwab_mcp`, which exposes a Click CLI, Schwab OAuth/token management, a FastMCP stdio server, request context wiring, static MCP resources, order preview caching, approval-gated write tooling, and registered Schwab API tools.
+
+## Design
+
+- `src/schwab_mcp/__init__.py` is the package entry point proxy; `main()` lazily imports `schwab_mcp.cli.main` so importing the package does not eagerly load CLI dependencies.
+- `src/schwab_mcp/cli.py` is the command boundary. It resolves credentials from flags, environment variables, and local credential files, then creates authenticated Schwab clients and server dependencies.
+- `src/schwab_mcp/server.py` adapts a Schwab `AsyncClient` into a FastMCP server, using lifespan-scoped dependency injection and a tool result transform strategy: Toon encoding by default or stripped JSON with `--json`.
+- `src/schwab_mcp/context.py` centralizes shared runtime state in `SchwabServerContext` and exposes typed protocol facades through `SchwabContext` properties.
+- `src/schwab_mcp/auth.py` and `src/schwab_mcp/tokens.py` isolate OAuth browser flow, token caching, token age validation, and secure local credential/token persistence.
+- `src/schwab_mcp/resources.py` registers static MCP reference resources. `src/schwab_mcp/previews.py` provides the in-memory TTL cache used by the order preview/place workflow.
+- `src/schwab_mcp/tools/` and `src/schwab_mcp/approvals/` are subpackages referenced by the core package: tools register MCP callable functions, while approvals provide write-operation authorization backends.
+
+## Flow
+
+1. The console entry point calls `schwab_mcp.main()`, which delegates to `cli.main()`.
+2. `schwab-mcp auth` loads stored credentials via `tokens.load_credentials()`, creates a `tokens.Manager`, and runs `auth.easy_client()` in interactive mode to write a Schwab OAuth token.
+3. `schwab-mcp server` resolves credentials, creates an async Schwab client through `auth.easy_client(interactive=False, asyncio=True)`, checks token age, chooses an approval manager, and instantiates `SchwabMCPServer`.
+4. `SchwabMCPServer` creates `FastMCP`, registers tool modules through `tools.register_tools()`, registers static resources through `resources.register_resources()`, and runs stdio transport.
+5. During FastMCP lifespan startup, `server._client_lifespan()` starts the approval manager and yields `SchwabServerContext`; tool calls receive `SchwabContext`, which exposes the raw client, typed client facades, approvals, and preview store.
+6. On shutdown, the lifespan finalizer stops the approval manager and closes the Schwab async HTTP session.
+
+## Integration
+
+- External APIs/libraries: `schwab-py` for OAuth and Schwab REST clients, `mcp.server.fastmcp.FastMCP` for MCP stdio serving, `click` for CLI commands, `anyio` for async execution, `platformdirs` and `yaml/json` for local persistence, and `toon` for compact tool payload encoding.
+- Main entry points: package `main()` in `src/schwab_mcp/__init__.py`; CLI commands `auth`, `server`, and `save-credentials` in `src/schwab_mcp/cli.py`; server runtime `SchwabMCPServer.run()` in `src/schwab_mcp/server.py`.
+- Security boundaries: credentials/tokens are stored under the user data directory with restricted permissions; server startup rejects missing credentials, stale tokens, non-async clients, and incomplete Discord approval configuration before serving MCP requests.
+- Tool/resource integration: `server.py` wires the core runtime to `src/schwab_mcp/tools` for Schwab operations and to `resources.py` for reference data; write tools are gated by approval managers unless explicitly bypassed with `--jesus-take-the-wheel`.

--- a/src/schwab_mcp/approvals/codemap.md
+++ b/src/schwab_mcp/approvals/codemap.md
@@ -1,0 +1,42 @@
+# src/schwab_mcp/approvals/
+
+## Responsibility
+
+Provides the approval abstraction and Discord-backed implementation used to gate Schwab write tools. The package defines a small backend interface (`ApprovalManager`), immutable request/decision types, a bypass manager for unrestricted mode, and the Discord workflow that turns a write request into an approve/deny/expired decision.
+
+## Design
+
+- `base.py` owns the stable contract:
+  - `ApprovalDecision` enum: `APPROVED`, `DENIED`, `EXPIRED`.
+  - `ApprovalRequest`: frozen dataclass carrying approval id, tool name, MCP request/client ids, and stringified arguments shown to reviewers.
+  - `ApprovalManager`: async lifecycle hooks (`start()`, `stop()`) plus abstract `require()`.
+  - `NoOpApprovalManager`: always approves, used when writes are disabled or explicitly bypassed.
+- `discord.py` implements `DiscordApprovalManager` around `discord.py`:
+  - `DiscordApprovalSettings` stores token, channel id, allowed approver ids, and timeout.
+  - `_ApprovalClient` is a thin `discord.Client` adapter that delegates readiness and reaction events back to the manager.
+  - `_PendingApproval` ties an `ApprovalRequest`, Discord message, and `asyncio.Future[ApprovalDecision]` together while a reviewer is deciding.
+- State is intentionally in-memory and process-local: a cached Discord channel, a pending-message map keyed by Discord message id, an async lock around pending state, and an event/task pair for bot readiness/lifecycle.
+- The Discord manager requires at least one explicit approver id; unauthorized reactions are ignored and best-effort removed.
+
+## Flow
+
+1. The server lifecycle calls `approval_manager.start()` before exposing the FastMCP context and `stop()` during shutdown.
+2. A write consumer builds an `ApprovalRequest` and calls `ApprovalManager.require()` (usually through `tools._registration.run_approval()`).
+3. For Discord approvals, `require()` ensures the bot is connected and the configured channel is messageable, posts an orange pending embed, and adds ✅/❌ reactions.
+4. The request is stored in `_pending` with a future. `require()` waits for that future with `timeout_seconds`.
+5. `on_reaction_add` delegates to `_handle_reaction_add()`, which filters out bots, wrong channels/messages, unsupported emoji, and unauthorized users.
+6. A valid ✅ sets `APPROVED`; a valid ❌ sets `DENIED`. The Discord message is edited to a final status embed including actor and notes, then the future is resolved.
+7. If no valid decision arrives before the timeout, `require()` records `EXPIRED`, edits the message with timeout notes, removes pending state, and returns the decision.
+8. If reaction setup fails, the manager finalizes the message as denied and returns `DENIED` so the write does not proceed silently.
+
+## Integration
+
+- `__init__.py` re-exports the approval API for the rest of the application.
+- `cli.py` chooses the manager:
+  - Discord settings are built from CLI/env inputs and enable write tools only when token, channel, and approvers are present.
+  - `--jesus-take-the-wheel` selects `NoOpApprovalManager`, enables write tools, and warns that Discord approvals are bypassed.
+  - Without Discord or bypass mode, `NoOpApprovalManager` is still provided to the server, but write tools are not registered.
+- `server.py` receives an `ApprovalManager`, starts/stops it in the FastMCP lifespan, and stores it in `SchwabServerContext`.
+- `context.py` exposes the active manager as `SchwabContext.approvals` for tool code.
+- `tools/_registration.py` is the primary consumer for automatically gated write tools: `register_tool(..., write=True)` wraps the function, creates an `ApprovalRequest` from formatted call arguments, reports MCP progress while waiting, calls `context.approvals.require()`, and only invokes the tool on `APPROVED`; `DENIED` raises `PermissionError`, `EXPIRED` raises `TimeoutError`.
+- `tools/orders.py` is a specialized consumer: `place_previewed_order()` builds its own request using the cached preview summary instead of raw arguments, then uses `run_approval()` directly before placing the order. Automatic wrapping is bypassed for that tool while preserving destructive/write annotations.

--- a/src/schwab_mcp/codemap.md
+++ b/src/schwab_mcp/codemap.md
@@ -1,0 +1,38 @@
+# `src/schwab_mcp/`
+
+## Responsibility
+
+`schwab_mcp` is the application package for a Schwab-backed MCP server. It owns the public entry point, CLI commands, OAuth/token lifecycle, FastMCP server construction, request context model, static MCP resources, and in-memory order preview cache. Tool implementations live under `schwab_mcp.tools`, and approval backends live under `schwab_mcp.approvals`; this directory wires those subpackages into the runtime.
+
+## Design
+
+- `__init__.py`: exposes `main()` as a lazy proxy to `schwab_mcp.cli.main`, avoiding eager import of Click and server dependencies for package importers.
+- `cli.py`: Click command surface. `auth` performs interactive OAuth token creation, `server` starts the MCP server, and `save-credentials` writes local Schwab API credentials. It validates required credentials before server startup and reports pre-initialization failures through MCP JSON-RPC error payloads.
+- `auth.py`: adapter around `schwab.auth`. `easy_client()` loads an existing token through a local `tokens.Manager`, rejects tokens older than `DEFAULT_MAX_TOKEN_AGE_SECONDS` when configured, or falls back to `client_from_login_flow()`. The login flow only permits `127.0.0.1` callback hosts and runs the redirect listener in a `multiprocess.Process`.
+- `tokens.py`: filesystem persistence layer. `token_path()` and `credentials_path()` resolve files under `platformdirs.user_data_dir`; `token_writer()`/`token_loader()` support YAML and JSON token files; `save_credentials()` writes YAML credentials with `0o600` permissions; `Manager` binds a token path to schwab-py-compatible load/write callables.
+- `server.py`: FastMCP adapter. `SchwabMCPServer` constructs `FastMCP`, installs `_client_lifespan()`, registers tools/resources, and chooses a result transform: Toon-encoded stripped payloads by default or stripped JSON when `use_json=True`. `send_error_response()` emits JSON-RPC 2.0 errors to stdout before the MCP server is initialized.
+- `context.py`: typed dependency container. `SchwabServerContext` stores the raw `AsyncClient`, `ApprovalManager`, `PreviewStore`, and typed client facades cast from `schwab_mcp.tools._protocols`. `SchwabContext` subclasses FastMCP `Context` and exposes safe properties for tools.
+- `resources.py`: static MCP reference resource registry for order statuses, order types/workflows, option symbol formats, and trading sessions. `register_resources()` binds them to `schwab://reference/...` URIs.
+- `previews.py`: TTL cache for the two-step order workflow. `PreviewStore.put()` deep-copies an order spec and returns a cryptographically random 16-character hex ID; `pop()` validates expiry and account hash, deletes on use, and returns the stored `PreviewEntry`.
+
+Key architectural patterns are lifespan-scoped dependency injection, protocol-based facades over the Schwab client, command-line dependency assembly, explicit pre-server error reporting, result transformation at registration time, and preview-then-place order safety.
+
+## Flow
+
+1. Console execution enters `schwab_mcp.__init__.main()`, which imports and calls `cli.main()`.
+2. `cli.auth()` resolves `SCHWAB_CLIENT_ID`, `SCHWAB_CLIENT_SECRET`, and callback/base URLs from options, environment, or `tokens.load_credentials()`, then calls `auth.easy_client(..., interactive=True)` to create and persist a token.
+3. `cli.server()` resolves credentials, creates a `tokens.Manager`, calls `auth.easy_client(..., asyncio=True, interactive=False, enforce_enums=False)`, verifies the result is `schwab.client.AsyncClient`, and rejects tokens older than five days.
+4. The server command selects write permissions: `--jesus-take-the-wheel` uses `NoOpApprovalManager` and enables writes; Discord configuration creates `DiscordApprovalManager`; otherwise writes are disabled and a no-op manager is still used for lifecycle consistency.
+5. `SchwabMCPServer.__init__()` creates `FastMCP` with `_client_lifespan()`, registers all tools via `tools.register_tools()` with write/technical/result-transform flags, then registers resources via `resources.register_resources()`.
+6. On FastMCP startup, `_client_lifespan()` starts the approval manager and yields `SchwabServerContext`. Tool registration wrappers in `schwab_mcp.tools._registration` convert generic MCP contexts to `SchwabContext`, apply approval gating for write tools, and apply the configured result transform.
+7. During tool execution, code accesses Schwab APIs through `ctx.accounts`, `ctx.orders`, `ctx.quotes`, `ctx.options`, `ctx.price_history`, `ctx.transactions`, or `ctx.tools`; order placement tools use `ctx.previews` for preview IDs and exact-spec execution.
+8. On shutdown, `_client_lifespan()` stops the approval manager and closes the Schwab async client session, logging cleanup failures without masking shutdown.
+
+## Integration
+
+- Entry points: `schwab_mcp.main()`, Click commands in `cli.py`, and `SchwabMCPServer.run()` for FastMCP stdio transport.
+- Schwab integration: `auth.py` delegates to `schwab.auth` and returns `schwab.client.Client` or `AsyncClient`; server mode requires `AsyncClient` and passes it through typed facades in `context.py`.
+- MCP integration: `server.py` uses `mcp.server.fastmcp.FastMCP`; `context.py` subclasses FastMCP `Context`; `resources.py` registers URI-addressable resources; `tools.register_tools()` registers callable Schwab operations.
+- Approval integration: `cli.py` constructs either `NoOpApprovalManager` or `DiscordApprovalManager`; `server._client_lifespan()` owns start/stop; `tools._registration.register_tool()` wraps write tools with approval requests and progress reporting.
+- Persistence/security integration: `tokens.py` stores OAuth tokens and credentials in the user data directory, supports YAML/JSON tokens, and uses restricted file modes for sensitive data.
+- Output integration: server results are normalized with `schwab_mcp.tools.utils.strip_noise`; non-JSON mode requires `toon.encode` to produce compact string payloads for MCP clients.

--- a/src/schwab_mcp/tools/codemap.md
+++ b/src/schwab_mcp/tools/codemap.md
@@ -1,0 +1,71 @@
+# src/schwab_mcp/tools/
+
+## Responsibility
+
+MCP tool layer for the Schwab API. It exposes read-only market/account data,
+transaction and order lookup, option chains, price history, and gated order
+actions through FastMCP tools. Modules keep Schwab client calls small and typed,
+normalize user-friendly string/date inputs, and shape large Schwab payloads into
+compact defaults with `verbose=True` escape hatches where response size matters.
+
+## Design
+
+- `__init__.py` is the aggregator: `register_tools()` calls each module's
+  `register()` and conditionally adds `technical/` tools when enabled.
+- `_registration.py` centralizes FastMCP registration. `register_tool()` converts
+  MCP `Context` arguments into `SchwabContext`, attaches read/write annotations,
+  applies optional `result_transform`, and wraps write tools in the approval
+  workflow unless a tool supplies custom approval handling.
+- `_protocols.py` defines Protocol facades for each Schwab client namespace
+  (`accounts`, `orders`, `quotes`, `options`, `price_history`, etc.). These keep
+  `SchwabContext` access type-checkable without coupling tool code to concrete
+  schwab-py implementations.
+- `utils.py` owns shared parsing and API behavior: `call()` awaits Schwab client
+  methods, raises `SchwabAPIError` with status/url/body on non-2xx responses,
+  handles empty 201/204 bodies, supports endpoint-specific response handlers,
+  and returns the JSON type alias used by all tools.
+- Response shaping is intentionally local to each domain: accounts prune balances
+  and positions while enriching hashes/nicknames, quotes keep key quote fields,
+  options prune per-contract greeks/liquidity fields and default expiration
+  windows to 60 days, and orders prune nested order payloads recursively.
+- Order construction is split between `orders.py` orchestration and
+  `order_helpers.py` builder factories. Helpers return configured schwab-py
+  `OrderBuilder` instances for equity, option, stop/limit, and trailing-stop
+  primitives; `orders.py` validates user parameters and composes single, OCO,
+  trigger, bracket, and option-combo specs.
+
+## Flow
+
+1. Server startup calls `register_tools(server, client, allow_write, ...)`.
+2. Each module registers its read-only tuple through `register_tool()`; `orders`
+   only registers write tools when `allow_write=True`.
+3. At invocation, FastMCP passes an MCP context. Registration wrappers convert it
+   to `SchwabContext`, whose typed Protocol-backed properties expose the relevant
+   Schwab client facade.
+4. Tool functions parse strings/dates, map enum names through Schwab client
+   namespaces, and call Schwab endpoints via `await call(...)`.
+5. Raw JSON is returned directly for simple endpoints or pruned/enriched before
+   returning to the MCP caller. Compact mode is the default for high-volume
+   accounts, quotes, options, and orders.
+6. Order preview tools build an exact order spec, submit Schwab `preview_order`,
+   cache the spec in `ctx.previews`, and return `preview_id` plus reviewer/user
+   action text. `place_previewed_order()` consumes that cached spec, creates a
+   custom approval request with a human-readable summary, places the exact order,
+   and returns compact post-placement order status. `cancel_order()` uses the
+   generic write-tool approval wrapper.
+
+## Integration
+
+- Depends on `schwab_mcp.context.SchwabContext` for per-request access to the
+  Schwab async client facades, approval manager, preview cache, request metadata,
+  and progress/warning reporting.
+- Uses FastMCP's `server.tool()` through `_registration.register_tool()` so tool
+  docs, annotations, and parameter metadata come from Python signatures/docstrings.
+- Integrates with `schwab_mcp.approvals` for write safeguards: automatic approval
+  wrapping for simple writes and explicit approval requests for previewed order
+  placement.
+- Integrates with schwab-py enums, order builders, and option symbol helpers but
+  shields callers from most enum/object details by accepting strings/lists/dates.
+- `technical/` is an optional child package registered by this folder's
+  aggregator; it reuses `ctx.price_history` and `call()` to compute derived
+  indicators from Schwab candle data when `pandas_ta_classic` is installed.

--- a/src/schwab_mcp/tools/technical/codemap.md
+++ b/src/schwab_mcp/tools/technical/codemap.md
@@ -1,0 +1,64 @@
+# src/schwab_mcp/tools/technical/
+
+## Responsibility
+
+Optional technical-analysis MCP tools. They fetch Schwab price history, convert
+candles into pandas frames, compute indicators, and return compact JSON rows for
+recent values. Available indicators include moving averages, RSI/stochastic,
+MACD/ATR/ADX, VWAP/Bollinger/pivot points, historical volatility, and expected
+move helpers.
+
+## Design
+
+- `__init__.py` is an optional-dependency gate. It imports
+  `pandas_ta_classic` once, exposes it as `pandas_ta`, and skips all technical
+  registration when the package is missing. If present, it lazily imports and
+  registers the indicator modules.
+- Each indicator module has a `register()` function and uses the parent
+  `_registration.register_tool()` path, so MCP context conversion, annotations,
+  and result transforms behave the same as non-technical tools. All tools are
+  read-only; `allow_write` is ignored.
+- `base.py` provides the shared indicator pipeline: interval normalization,
+  Schwab price-history fetches, candle-to-DataFrame conversion, required-column
+  validation, warm-up window sizing, and JSON serialization.
+- `compute_series_indicator()` and `compute_frame_indicator()` reduce repeated
+  logic for pandas-ta indicators, enforcing Series/DataFrame expectations,
+  dropping warm-up nulls, limiting output rows via `points`, and returning common
+  metadata (`symbol`, `interval`, `start`, `end`, `candles`, parameters).
+- Not every calculation is delegated to pandas-ta: pivot points are implemented
+  directly because the pinned `pandas_ta_classic` versions do not expose a
+  compatible pivot-point function. Volatility tools use pandas/numpy math for
+  domain-specific statistics and compact summaries.
+
+## Flow
+
+1. Parent `tools.register_tools(..., enable_technical=True)` calls
+   `technical.register()`.
+2. `technical.register()` returns immediately if `pandas_ta_classic` is not
+   installed; otherwise it imports `moving_average`, `momentum`, `trend`,
+   `overlays`, and `volatility`, then calls each module's `register()`.
+3. An indicator invocation validates local parameters and computes a padded bar
+   window with `compute_window()` or tool-specific sizing.
+4. `fetch_price_frame()` maps intervals (`1m`, `5m`, `10m`, `15m`, `30m`, `1d`,
+   `1w`) to the matching `ctx.price_history` convenience method, calls it through
+   `call()`, converts the returned `candles` list into a time-indexed OHLCV
+   DataFrame, and records fetch metadata.
+5. The indicator function computes one or more pandas Series, null warm-up rows
+   are dropped, and `series_to_json()`/`frame_to_json()` returns only recent rows
+   (default up to three, controlled by `points`) with ISO UTC timestamps and
+   rounded numeric values.
+
+## Integration
+
+- Registered only through `src/schwab_mcp/tools/__init__.py`; disabling technical
+  tools or omitting `pandas_ta_classic` leaves the rest of the Schwab tools
+  unaffected.
+- Uses `SchwabContext.price_history`, whose client surface is described by the
+  Protocol facades in `tools/_protocols.py`, and uses the shared `call()` helper
+  for consistent Schwab error handling and JSON extraction.
+- Shares FastMCP registration behavior with the parent tool package, including
+  context wrapping and optional result transformation.
+- Produces compact, model-friendly responses instead of raw candles or pandas
+  objects: metadata plus recent computed values. Callers that need more output
+  increase `points`; callers that need more calculation history pass explicit
+  `start`/`end` or volatility `bars` where supported.


### PR DESCRIPTION
Add a repository codemap so future work starts with a compact map of the package, tool layer, approval flow, and technical-analysis modules.

This also updates `AGENTS.md` to point agents at the codemap and asks them to refresh the relevant maps when source changes alter responsibilities, entry points, flow, integrations, or directory structure.

Tests:
- `make check`
- `make test-cov`
