### PR TITLE
feat(cli): add streamable-http transport for gateway deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Start the MCP server to expose the tools to your MCP client.
 # Basic Read-Only Mode (Safest)
 schwab-mcp server --client-id YOUR_KEY --client-secret YOUR_SECRET
 
+# Streamable HTTP (for reverse proxies / remote MCP connectors)
+schwab-mcp server --client-id YOUR_KEY --client-secret YOUR_SECRET \
+  --http --host 127.0.0.1 --port 8000
+
 # With Trading Enabled (Requires Discord Approval)
 schwab-mcp server \
   --client-id YOUR_KEY \
@@ -60,6 +64,10 @@ schwab-mcp server \
   --discord-channel-id CHANNEL_ID \
   --discord-approver YOUR_USER_ID
 ```
+
+Default transport is **stdio** (Claude Desktop and most local MCP clients).
+Use `--http` for FastMCP streamable-http when fronting the server with a
+gateway or remote connector (MCP endpoint is `/mcp` on the bound host:port).
 
 > **Note**: For trading capabilities, you must set up a Discord bot for approvals. See [Discord Setup Guide](docs/discord-setup.md).
 
@@ -73,6 +81,9 @@ You can configure the server using CLI flags or Environment Variables.
 | `--client-secret` | `SCHWAB_CLIENT_SECRET` | **Required**. Schwab App Secret. |
 | `--callback-url` | `SCHWAB_CALLBACK_URL` | Redirect URL (default: `https://127.0.0.1:8182`). |
 | `--token-path` | N/A | Path to save/load token (default: `~/.local/share/...`). |
+| `--http` | N/A | Use streamable-http transport instead of stdio. |
+| `--host` | `MCP_HOST` | Bind address when using `--http` (default: `127.0.0.1`). |
+| `--port` | `MCP_PORT` | Bind port when using `--http` (default: `8000`). |
 | `--jesus-take-the-wheel`| N/A | **DANGER**. Bypasses Discord approval for trades. |
 | `--no-technical-tools` | N/A | Disables technical analysis tools (SMA, RSI, etc.). |
 | `--json` | N/A | Returns JSON instead of formatted text (useful for some agents). Null/empty fields are stripped to reduce token usage. |

--- a/src/schwab_mcp/cli.py
+++ b/src/schwab_mcp/cli.py
@@ -185,6 +185,29 @@ def auth(
     is_flag=True,
     help="Return JSON payloads from tools instead of Toon-encoded strings.",
 )
+@click.option(
+    "--http",
+    "use_http",
+    default=False,
+    is_flag=True,
+    help="Use streamable-http transport (binds to --host/--port) instead of stdio.",
+)
+@click.option(
+    "--host",
+    type=str,
+    default="127.0.0.1",
+    envvar="MCP_HOST",
+    show_default=True,
+    help="Host interface to bind when using --http (use 0.0.0.0 for gateway).",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=8000,
+    envvar="MCP_PORT",
+    show_default=True,
+    help="TCP port when using --http transport.",
+)
 def server(
     token_path: str,
     client_id: str | None,
@@ -198,6 +221,9 @@ def server(
     discord_timeout: int,
     no_technical_tools: bool,
     json_output: bool,
+    use_http: bool,
+    host: str,
+    port: int,
 ) -> int:
     """Run the Schwab MCP server."""
     creds = tokens.load_credentials(tokens.credentials_path(APP_NAME))
@@ -322,7 +348,8 @@ def server(
             enable_technical_tools=not no_technical_tools,
             use_json=json_output,
         )
-        anyio.run(server.run, backend="asyncio")
+        transport = "streamable-http" if use_http else "stdio"
+        anyio.run(server.run, transport, host, port, backend="asyncio")
         return 0
     except Exception as e:
         send_error_response(f"Error running server: {str(e)}", code=500, details={"error": str(e)})

--- a/src/schwab_mcp/server.py
+++ b/src/schwab_mcp/server.py
@@ -95,9 +95,23 @@ class SchwabMCPServer:
         )
         register_resources(self._server)
 
-    async def run(self) -> None:
-        """Run the server using FastMCP's stdio transport."""
-        await self._server.run_stdio_async()
+    async def run(
+        self,
+        transport: str = "stdio",
+        host: str = "127.0.0.1",
+        port: int = 8000,
+    ) -> None:
+        """Run the server over stdio (default) or streamable-http for gateway use."""
+        resolved = transport.strip().lower()
+        if resolved in ("http", "streamable_http", "streamable-http"):
+            self._server.settings.host = host
+            self._server.settings.port = port
+            await self._server.run_streamable_http_async()
+            return
+        if resolved == "stdio":
+            await self._server.run_stdio_async()
+            return
+        raise ValueError(f"Unknown transport {transport!r}; use stdio or streamable-http (or http)")
 
 
 def send_error_response(error_message: str, code: int = 401, details: dict | None = None) -> None:

--- a/tests/test_cli_credentials.py
+++ b/tests/test_cli_credentials.py
@@ -115,7 +115,7 @@ class TestServerCredentialsFile:
             "SchwabMCPServer",
             lambda *a, **kw: type("S", (), {"run": staticmethod(lambda: None)})(),
         )
-        monkeypatch.setattr(cli.anyio, "run", lambda func, **kw: None)
+        monkeypatch.setattr(cli.anyio, "run", lambda func, *args, **kw: None)
 
     def test_falls_back_to_credentials_file(self, monkeypatch, tmp_path):
         captured: dict[str, Any] = {}

--- a/tests/test_cli_server_write_modes.py
+++ b/tests/test_cli_server_write_modes.py
@@ -77,7 +77,11 @@ def _patch_common(monkeypatch, captured: dict[str, Any]) -> None:
     monkeypatch.setattr(
         cli.anyio,
         "run",
-        lambda func, backend="asyncio": captured.setdefault("anyio_backend", backend),
+        lambda func, *args, backend="asyncio", **kwargs: (
+            captured.setdefault("anyio_backend", backend),
+            captured.setdefault("anyio_args", args),
+            captured.setdefault("anyio_kwargs", kwargs),
+        ),
     )
 
 
@@ -463,7 +467,7 @@ def test_server_exits_when_server_run_raises(monkeypatch):
 
     monkeypatch.setattr(cli.schwab_auth, "easy_client", fake_easy_client)
 
-    def fake_run(func, backend="asyncio"):
+    def fake_run(func, *args, backend="asyncio", **kwargs):
         raise RuntimeError("server exploded during run")
 
     monkeypatch.setattr(cli.anyio, "run", fake_run)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -228,6 +228,31 @@ async def test_server_run_calls_run_stdio_async(monkeypatch) -> None:
     assert called.get("run") is True
 
 
+@pytest.mark.anyio
+async def test_server_run_http_calls_streamable_http(monkeypatch) -> None:
+    """--http path must set host/port and use run_streamable_http_async."""
+    called: dict[str, bool] = {}
+
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
+    approval_manager = DummyApprovalManager()
+    server = SchwabMCPServer(
+        "schwab-mcp",
+        client,
+        approval_manager=approval_manager,
+        allow_write=False,
+    )
+
+    async def fake_run_streamable_http_async() -> None:
+        called["http"] = True
+
+    monkeypatch.setattr(server._server, "run_streamable_http_async", fake_run_streamable_http_async)
+    await server.run(transport="http", host="127.0.0.1", port=3473)
+    assert called.get("http") is True
+    assert server._server.settings.host == "127.0.0.1"
+    assert server._server.settings.port == 3473
+
+
 def test_send_error_response_defaults_details_to_empty_dict(monkeypatch) -> None:
     """send_error_response without details= uses an empty dict, not None."""
     buf = io.StringIO()


### PR DESCRIPTION
## Summary

- Add optional `--http` transport to `schwab-mcp server` (FastMCP streamable-http)
- Bind address/port via `--host` / `--port` (or `MCP_HOST` / `MCP_PORT`)
- Keep **stdio as the default** for Claude Desktop and local MCP clients
- Document flags in the README and cover the HTTP run path with unit tests

This enables reverse-proxy / remote connector deployments (e.g. gateway fronting `http://host:port/mcp`) without changing the existing stdio workflow.

## Usage

```bash
# Default (stdio)
schwab-mcp server --client-id ... --client-secret ...

# Streamable HTTP
schwab-mcp server --client-id ... --client-secret ... \
  --http --host 127.0.0.1 --port 8000
```

## Test plan

- [x] `pytest tests/test_server.py tests/test_cli_server_write_modes.py tests/test_cli_credentials.py`
- [x] `ruff check` / `ruff format` on touched files
- [ ] CI green on this PR
- [ ] Manual smoke (optional): start with `--http`, POST `initialize` to `/mcp`, confirm `serverInfo.name` is `schwab-mcp`