### PR TITLE
fix(http): do not close shared AsyncClient on streamable-HTTP session end

### DIFF
--- a/src/codemap.md
+++ b/src/codemap.md
@@ -21,7 +21,7 @@
 3. `schwab-mcp server` resolves credentials, creates an async Schwab client through `auth.easy_client(interactive=False, asyncio=True)`, checks token age, chooses an approval manager, and instantiates `SchwabMCPServer`.
 4. `SchwabMCPServer` creates `FastMCP`, registers tool modules through `tools.register_tools()`, registers static resources through `resources.register_resources()`, and runs stdio transport.
 5. During FastMCP lifespan startup, `server._client_lifespan()` starts the approval manager and yields `SchwabServerContext`; tool calls receive `SchwabContext`, which exposes the raw client, typed client facades, approvals, and preview store.
-6. On shutdown, the lifespan finalizer stops the approval manager and closes the Schwab async HTTP session.
+6. On shutdown, the lifespan finalizer stops the approval manager. The process-scoped Schwab async client is left open (streamable-HTTP may exit lifespan per session).
 
 ## Integration
 

--- a/src/schwab_mcp/codemap.md
+++ b/src/schwab_mcp/codemap.md
@@ -26,7 +26,7 @@ Key architectural patterns are lifespan-scoped dependency injection, protocol-ba
 5. `SchwabMCPServer.__init__()` creates `FastMCP` with `_client_lifespan()`, registers all tools via `tools.register_tools()` with write/technical/result-transform flags, then registers resources via `resources.register_resources()`.
 6. On FastMCP startup, `_client_lifespan()` starts the approval manager and yields `SchwabServerContext`. Tool registration wrappers in `schwab_mcp.tools._registration` convert generic MCP contexts to `SchwabContext`, apply approval gating for write tools, and apply the configured result transform.
 7. During tool execution, code accesses Schwab APIs through `ctx.accounts`, `ctx.orders`, `ctx.quotes`, `ctx.options`, `ctx.price_history`, `ctx.transactions`, or `ctx.tools`; order placement tools use `ctx.previews` for preview IDs and exact-spec execution.
-8. On shutdown, `_client_lifespan()` stops the approval manager and closes the Schwab async client session, logging cleanup failures without masking shutdown.
+8. On shutdown, `_client_lifespan()` stops the approval manager. The process-scoped Schwab `AsyncClient` is not closed here: streamable-HTTP may tear down lifespan per MCP session, and closing the shared client would break subsequent sessions.
 
 ## Integration
 

--- a/src/schwab_mcp/server.py
+++ b/src/schwab_mcp/server.py
@@ -29,6 +29,10 @@ def _client_lifespan(
 
     @asynccontextmanager
     async def lifespan(_: FastMCP) -> AsyncGenerator[SchwabServerContext, None]:
+        # Streamable-HTTP may enter/exit this lifespan per MCP session. The
+        # AsyncClient is process-scoped (created once in CLI); closing it here
+        # kills every subsequent session ("Cannot send a request, as the client
+        # has been closed"). Leave session teardown to process exit.
         await approval_manager.start()
         context = SchwabServerContext(client=client, approval_manager=approval_manager)
         try:
@@ -38,10 +42,6 @@ def _client_lifespan(
                 await approval_manager.stop()
             except Exception:
                 logger.exception("Failed to shut down approval manager cleanly.")
-            try:
-                await client.close_async_session()
-            except Exception:
-                logger.exception("Failed to close Schwab async client session during shutdown.")
 
     return lifespan
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,44 +60,43 @@ def test_server_configures_client_lifespan() -> None:
             assert approval_manager.started is True
 
     asyncio.run(runner())
-    assert dummy_client.closed is True
-    assert dummy_client.calls == 1
+    # Process-scoped AsyncClient must outlive FastMCP lifespan teardown
+    # (streamable-HTTP may exit lifespan per MCP session).
+    assert dummy_client.closed is False
+    assert dummy_client.calls == 0
     assert approval_manager.stopped is True
 
 
-def test_server_logs_errors_when_closing_client(caplog) -> None:
-    class FailingClient:
-        def __init__(self) -> None:
-            self.calls = 0
-
-        async def close_async_session(self) -> None:
-            self.calls += 1
-            raise RuntimeError("boom")
-
-    failing_client = FailingClient()
-    client = cast(AsyncClient, failing_client)
+def test_lifespan_keeps_shared_client_open_across_sessions() -> None:
+    """Streamable-HTTP can enter/exit lifespan per session; client stays open."""
+    dummy_client = DummyAsyncClient()
+    client = cast(AsyncClient, dummy_client)
     approval_manager = DummyApprovalManager()
     server = SchwabMCPServer(
         "schwab-mcp",
         client,
         approval_manager=approval_manager,
-        allow_write=True,
+        allow_write=False,
     )
 
     lifespan_factory = server._server.settings.lifespan
     assert callable(lifespan_factory)
 
     async def runner() -> None:
-        async with lifespan_factory(server._server):
-            pass
+        for _ in range(2):
+            approval_manager.started = False
+            approval_manager.stopped = False
+            async with lifespan_factory(server._server) as context:
+                assert context.client is client
+                assert dummy_client.closed is False
+                assert approval_manager.started is True
+            assert dummy_client.closed is False
+            assert dummy_client.calls == 0
+            assert approval_manager.stopped is True
 
-    with caplog.at_level(logging.ERROR):
-        asyncio.run(runner())
-
-    assert failing_client.calls == 1
-    assert "Failed to close Schwab async client session during shutdown." in caplog.text
-    assert approval_manager.started is True
-    assert approval_manager.stopped is True
+    asyncio.run(runner())
+    assert dummy_client.closed is False
+    assert dummy_client.calls == 0
 
 
 def test_lifespan_logs_error_when_approval_manager_stop_raises(caplog) -> None:
@@ -136,8 +135,9 @@ def test_lifespan_logs_error_when_approval_manager_stop_raises(caplog) -> None:
 
     assert failing_approval.started is True
     assert "Failed to shut down approval manager cleanly." in caplog.text
-    # Client session close still runs after approval manager failure
-    assert dummy_client.closed is True
+    # Shared client must not be closed even when approval manager stop fails
+    assert dummy_client.closed is False
+    assert dummy_client.calls == 0
 
 
 def test_toon_transform_returns_string_payload_unchanged(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- FastMCP streamable-HTTP can enter/exit lifespan per MCP session. The previous lifespan teardown called `client.close_async_session()` on the process-scoped schwab-py `AsyncClient`, which made every subsequent session fail with "Cannot send a request, as the client has been closed".
- Stop closing the shared client in `_client_lifespan`; only stop the approval manager. Leave client cleanup to process exit.
- Update lifespan tests to assert the client stays open, add a multi-session regression test, and align codemap shutdown notes.

## Test plan
- [x] `uv run pytest` — 588 passed
- [x] `uv run ruff check .`
- [x] `uv run pyright`
- [x] `uv run ruff format --check .`
- [ ] CI green on this PR across Python matrix