### PR TITLE
fix(options): accept Schwab strike range values

### DIFF
--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -84,6 +84,22 @@ def _normalize_expiration_window(
     return from_date, to_date
 
 
+def _parse_strike_range(client: Any, strike_range: str | None) -> Any:
+    if strike_range is None:
+        return None
+
+    enum_type = client.Options.StrikeRange
+    normalized = strike_range.upper()
+    try:
+        return enum_type[normalized]
+    except KeyError:
+        try:
+            return enum_type(normalized)
+        except ValueError as exc:
+            choices = ", ".join(member.name for member in enum_type)
+            raise ValueError(f"Invalid strike_range: {strike_range}. Must be one of: {choices}") from exc
+
+
 async def get_option_chain(
     ctx: SchwabContext,
     symbol: Annotated[str, "Symbol of the underlying security (e.g., 'AAPL', 'SPY')"],
@@ -150,7 +166,9 @@ async def get_advanced_option_chain(
     strike: Annotated[float | None, "Only return options with the given strike"] = None,
     strike_range: Annotated[
         str | None,
-        "Filter strikes: IN_THE_MONEY, NEAR_THE_MONEY, OUT_OF_THE_MONEY, STRIKES_ABOVE_MARKET, STRIKES_BELOW_MARKET, STRIKES_NEAR_MARKET, ALL (default)",
+        "Filter strikes by enum name or Schwab value: IN_THE_MONEY/ITM, "
+        "NEAR_THE_MONEY/NTM, OUT_OF_THE_MONEY/OTM, STRIKES_ABOVE_MARKET/SAK, "
+        "STRIKES_BELOW_MARKET/SBK, STRIKES_NEAR_MARKET/SNK, ALL",
     ] = None,
     from_date: Annotated[
         str | datetime.date | None,
@@ -172,7 +190,7 @@ async def get_advanced_option_chain(
     ] = False,
 ) -> JSONType:
     """Returns advanced option chain data with strategies, filters, and theoretical calculations. Use for complex analysis.
-    Params: symbol, contract_type, strike_count, include_quotes, strategy (SINGLE/ANALYTICAL/etc.), interval, strike, strike_range (ITM/NTM/etc.), from/to_date, volatility/underlying_price/interest_rate/days_to_expiration (for ANALYTICAL), exp_month, option_type (STANDARD/NON_STANDARD/ALL).
+    Params: symbol, contract_type, strike_count, include_quotes, strategy (SINGLE/ANALYTICAL/etc.), interval, strike, strike_range (enum name or ITM/NTM/etc.), from/to_date, volatility/underlying_price/interest_rate/days_to_expiration (for ANALYTICAL), exp_month, option_type (STANDARD/NON_STANDARD/ALL).
     Limit data returned using strike_count and date parameters. When both dates are omitted the tool defaults to the next 60 calendar days to avoid oversized responses.
     By default returns compact per-contract fields only; pass verbose=True for the full raw payload.
     """
@@ -194,7 +212,7 @@ async def get_advanced_option_chain(
         strategy=client.Options.Strategy[strategy.upper()] if strategy else None,
         interval=interval,
         strike=strike,
-        strike_range=client.Options.StrikeRange[strike_range.upper()] if strike_range else None,
+        strike_range=_parse_strike_range(client, strike_range),
         from_date=from_date_obj,
         to_date=to_date_obj,
         volatility=volatility,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -13,7 +13,15 @@ class DummyOptionsClient:
         Strategy = Enum("Strategy", "SINGLE ANALYTICAL VERTICAL")
         StrikeRange = Enum(
             "StrikeRange",
-            "IN_THE_MONEY NEAR_THE_MONEY OUT_OF_THE_MONEY STRIKES_ABOVE_MARKET STRIKES_BELOW_MARKET STRIKES_NEAR_MARKET ALL",
+            {
+                "IN_THE_MONEY": "ITM",
+                "NEAR_THE_MONEY": "NTM",
+                "OUT_OF_THE_MONEY": "OTM",
+                "STRIKES_ABOVE_MARKET": "SAK",
+                "STRIKES_BELOW_MARKET": "SBK",
+                "STRIKES_NEAR_MARKET": "SNK",
+                "ALL": "ALL",
+            },
         )
         ExpirationMonth = Enum("ExpirationMonth", "JAN FEB MAR")
         Type = Enum("Type", "STANDARD NON_STANDARD ALL")
@@ -78,6 +86,30 @@ def test_get_advanced_option_chain_parses_and_maps_parameters(monkeypatch, fake_
     assert kwargs["days_to_expiration"] == 30
     assert kwargs["exp_month"] is client.Options.ExpirationMonth.JAN
     assert kwargs["option_type"] is client.Options.Type.STANDARD
+
+
+def test_get_advanced_option_chain_accepts_schwab_strike_range_value(monkeypatch, fake_call_factory):
+    captured, fake_call = fake_call_factory()
+    monkeypatch.setattr(options, "call", fake_call)
+
+    client = DummyOptionsClient()
+    run(options.get_advanced_option_chain(make_ctx(client), "SPY", strike_range="OTM"))
+
+    assert captured["kwargs"]["strike_range"] is client.Options.StrikeRange.OUT_OF_THE_MONEY
+
+
+def test_get_advanced_option_chain_rejects_invalid_strike_range():
+    client = DummyOptionsClient()
+
+    try:
+        run(options.get_advanced_option_chain(make_ctx(client), "SPY", strike_range="invalid"))
+    except ValueError as exc:
+        assert str(exc) == (
+            "Invalid strike_range: invalid. Must be one of: IN_THE_MONEY, NEAR_THE_MONEY, "
+            "OUT_OF_THE_MONEY, STRIKES_ABOVE_MARKET, STRIKES_BELOW_MARKET, STRIKES_NEAR_MARKET, ALL"
+        )
+    else:
+        raise AssertionError("expected invalid strike_range to raise ValueError")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Accept Schwab strike-range values such as `ITM`, `NTM`, and `OTM` in the advanced option-chain tool.
- Validate invalid values with an actionable error listing the supported enum names.

## Test plan
- [x] `make check`
- [x] 590 tests passed
