### PR TITLE
chore(ci): mirror make check in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,4 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.9
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.23.1
-    hooks:
-      - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -18,3 +8,42 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.1
+    hooks:
+      - id: gitleaks
+  # Project checks via `uv run` so tool versions stay in sync with the
+  # lockfile. Mirrors `make check` (format-check, lint, typecheck, deadcode,
+  # test), cheapest first so failures surface early.
+  - repo: local
+    hooks:
+      - id: ruff-format
+        name: ruff format
+        entry: uv run ruff format
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: ruff-check
+        name: ruff check
+        entry: uv run ruff check --fix --output-format=concise
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: pyright
+        name: pyright
+        entry: uv run pyright
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: vulture
+        name: vulture
+        entry: uv run vulture
+        language: system
+        types: [python]
+        pass_filenames: false
+      - id: pytest
+        name: pytest
+        entry: uv run pytest -q --no-cov
+        language: system
+        types: [python]
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- Replace the pinned `ruff-pre-commit` repo (v0.15.9, drifting from the project's actual 0.15.22) with local `uv run` hooks so ruff versions stay in sync with the lockfile instead of a separate pinned rev.
- Add `pyright`, `vulture`, and `pytest` as local `uv run` hooks so pre-commit mirrors `make check` (format-check, lint, typecheck, deadcode, test).
- Reorder all hooks cheapest-first so failures surface early, matching the Makefile's ordering philosophy.
- All project-check hooks use `pass_filenames: false` since these tools check the whole repo, not just staged files.

## Test plan
- [x] `pre-commit run --all-files` — all 11 hooks pass
- [x] `make check`