### PR TITLE
fix(deps): pin mcp below v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click>=8.3.0",
     "discord.py>=2.4.0",
     "httpx>=0.27.2",
-    "mcp>=1.17.0",
+    "mcp>=1.17.0,<2",
     "platformdirs>=4.5.0",
     "python-toon>=0.1.2",
     "pyyaml>=6.0.3",
@@ -29,7 +29,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "mcp[cli]>=1.17.0",
+    "mcp[cli]>=1.17.0,<2",
     "pyright>=1.1.407",
     "pytest>=8.4.2",
     "pytest-cov>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2498,7 +2498,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
     { name = "discord-py", specifier = ">=2.4.0" },
     { name = "httpx", specifier = ">=0.27.2" },
-    { name = "mcp", specifier = ">=1.17.0" },
+    { name = "mcp", specifier = ">=1.17.0,<2" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "python-toon", specifier = ">=0.1.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -2508,7 +2508,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.17.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.17.0,<2" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },


### PR DESCRIPTION
## Summary

Pin `mcp` to `>=1.17.0,<2` to stop Renovate's lock-file-maintenance PR (#155) from resolving to `mcp 2.0.0`, which breaks the build.

## Why

`mcp 2.0.0` is a major release that:

- Splits wire types into a separate `mcp-types` package
- Renames `FastMCP` to `MCPServer` and moves `mcp.server.fastmcp` to `mcp.server.mcpserver`
- Converts every `ToolAnnotations` field from camelCase to snake_case (`readOnlyHint` → `read_only_hint`, `destructiveHint` → `destructive_hint`)

These are breaking import and type changes that pyright catches across `_registration.py`, `orders.py`, `test_registry.py`, and `test_server.py`. Rebasing #155 cannot fix this because the lock file resolves to the breaking version every time.

Per the upstream [migration guide](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/whats-new.md), v1.x is now maintenance-only and library authors should add an upper bound (`mcp<2`) if they are not ready to migrate.

## What changed

- `pyproject.toml`: `mcp>=1.17.0` → `mcp>=1.17.0,<2` (both `dependencies` and `dev` groups)
- `uv.lock`: re-resolved to `mcp 1.28.1` (v1 tail)

## Verification

- `uv run pyright` — 0 errors
- `uv run ruff check .` — clean
- `uv run pytest` — 590 passed

## Next step

A dedicated PR should migrate to `mcp` v2 (rename `FastMCP` → `MCPServer`, snake_case all wire-type fields, fix lifespan tests, swap `httpx` → `httpx2`). Once that lands, this `<2` cap can be removed.