### PR TITLE
feat(deps): migrate to mcp SDK v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "click>=8.3.0",
     "discord.py>=2.4.0",
     "httpx>=0.27.2",
-    "mcp>=1.17.0,<2",
+    "mcp>=2.0.0,<3",
     "platformdirs>=4.5.0",
     "python-toon>=0.1.2",
     "pyyaml>=6.0.3",
@@ -29,7 +29,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "mcp[cli]>=1.17.0,<2",
+    "mcp[cli]>=2.0.0,<3",
     "pyright>=1.1.407",
     "pytest>=8.4.2",
     "pytest-cov>=6.0.0",

--- a/src/schwab_mcp/context.py
+++ b/src/schwab_mcp/context.py
@@ -1,11 +1,11 @@
-"""FastMCP context types that expose the Schwab client and supporting services."""
+"""MCPServer context types that expose the Schwab client and supporting services."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
-from mcp.server.fastmcp import Context as MCPContext
+from mcp.server.mcpserver import Context as MCPContext
 from schwab.client import AsyncClient
 
 from schwab_mcp.approvals import ApprovalManager
@@ -29,7 +29,7 @@ else:  # pragma: no cover - runtime only
 
 @dataclass(slots=True)
 class SchwabServerContext:
-    """Typed application context shared via FastMCP lifespan."""
+    """Typed application context shared via MCPServer lifespan."""
 
     client: AsyncClient
     approval_manager: ApprovalManager
@@ -52,8 +52,8 @@ class SchwabServerContext:
         self.transactions = cast(TransactionsClient, self.client)
 
 
-class SchwabContext(MCPContext[Any, SchwabServerContext, Any]):
-    """FastMCP context with typed accessors for Schwab APIs."""
+class SchwabContext(MCPContext[SchwabServerContext, Any]):
+    """MCPServer context with typed accessors for Schwab APIs."""
 
     @property
     def schwab(self) -> SchwabServerContext:
@@ -62,6 +62,17 @@ class SchwabContext(MCPContext[Any, SchwabServerContext, Any]):
         if context is None:
             raise RuntimeError("Schwab context is unavailable outside a request")
         return context
+
+    @property
+    def client_id(self) -> str | None:
+        """Return the client ID if available in request metadata."""
+        try:
+            meta = self.request_context.meta
+        except ValueError:
+            return None
+        if meta is None:
+            return None
+        return meta.get("client_id")
 
     @property
     def client(self) -> AsyncClient:

--- a/src/schwab_mcp/resources.py
+++ b/src/schwab_mcp/resources.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 ORDER_STATUSES: dict[str, Any] = {
     "statuses": {
@@ -232,7 +232,7 @@ TRADING_SESSIONS: dict[str, Any] = {
 }
 
 
-def register_resources(server: FastMCP) -> None:
+def register_resources(server: MCPServer) -> None:
     """Register all static reference resources with the MCP server."""
 
     @server.resource("schwab://reference/order-statuses")

--- a/src/schwab_mcp/server.py
+++ b/src/schwab_mcp/server.py
@@ -1,4 +1,4 @@
-"""FastMCP server setup and lifecycle management for schwab-mcp."""
+"""MCPServer server setup and lifecycle management for schwab-mcp."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from typing import Any
 
 import mcp.types as types
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from schwab.client import AsyncClient
 
 from schwab_mcp.approvals import ApprovalManager
@@ -24,11 +24,11 @@ logger = logging.getLogger(__name__)
 def _client_lifespan(
     client: AsyncClient,
     approval_manager: ApprovalManager,
-) -> Callable[[FastMCP], AbstractAsyncContextManager[SchwabServerContext]]:
-    """Create a FastMCP lifespan context that exposes the Schwab async client."""
+) -> Callable[[MCPServer], AbstractAsyncContextManager[SchwabServerContext]]:
+    """Create an MCPServer lifespan context that exposes the Schwab async client."""
 
     @asynccontextmanager
-    async def lifespan(_: FastMCP) -> AsyncGenerator[SchwabServerContext, None]:
+    async def lifespan(_: MCPServer) -> AsyncGenerator[SchwabServerContext, None]:
         # Streamable-HTTP may enter/exit this lifespan per MCP session. The
         # AsyncClient is process-scoped (created once in CLI); closing it here
         # kills every subsequent session ("Cannot send a request, as the client
@@ -47,7 +47,7 @@ def _client_lifespan(
 
 
 class SchwabMCPServer:
-    """Schwab Model Context Protocol server backed by FastMCP."""
+    """Schwab Model Context Protocol server backed by MCPServer."""
 
     def __init__(
         self,
@@ -82,7 +82,7 @@ class SchwabMCPServer:
 
             result_transform = _json_strip_transform
 
-        self._server = FastMCP(
+        self._server = MCPServer(
             name=name,
             lifespan=_client_lifespan(client, approval_manager),
         )
@@ -104,9 +104,7 @@ class SchwabMCPServer:
         """Run the server over stdio (default) or streamable-http for gateway use."""
         resolved = transport.strip().lower()
         if resolved in ("http", "streamable_http", "streamable-http"):
-            self._server.settings.host = host
-            self._server.settings.port = port
-            await self._server.run_streamable_http_async()
+            await self._server.run_streamable_http_async(host=host, port=port)
             return
         if resolved == "stdio":
             await self._server.run_stdio_async()

--- a/src/schwab_mcp/tools/__init__.py
+++ b/src/schwab_mcp/tools/__init__.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from schwab.client import AsyncClient
 
 from schwab_mcp.tools import (
@@ -34,14 +34,14 @@ _TOOL_MODULES = (
 
 
 def register_tools(
-    server: FastMCP,
+    server: MCPServer,
     client: AsyncClient,
     *,
     allow_write: bool,
     enable_technical: bool = True,
     result_transform: Callable[[Any], Any] | None = None,
 ) -> None:
-    """Register all Schwab tools with the provided FastMCP server."""
+    """Register all Schwab tools with the provided MCPServer server."""
     _ = client
 
     modules = _TOOL_MODULES

--- a/src/schwab_mcp/tools/_registration.py
+++ b/src/schwab_mcp/tools/_registration.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from typing import Annotated, Any, Union, cast, get_args, get_origin, get_type_hints
 
-from mcp.server.fastmcp import Context as MCPContext, FastMCP
+from mcp.server.mcpserver import Context as MCPContext, MCPServer
 from mcp.types import ToolAnnotations
 
 from schwab_mcp.approvals import ApprovalDecision, ApprovalRequest
@@ -89,7 +89,7 @@ def _ensure_schwab_context(func: ToolFn) -> ToolFn:
             if isinstance(value, MCPContext):
                 bound.arguments[name] = SchwabContext.model_construct(
                     _request_context=value.request_context,
-                    _fastmcp=getattr(value, "_fastmcp", None),
+                    _mcp_server=getattr(value, "_mcp_server", None),
                 )
             else:
                 raise TypeError(f"Argument '{name}' must be an MCP context, got {type(value)!r}")
@@ -165,7 +165,7 @@ def _wrap_with_approval(func: ToolFn) -> ToolFn:
             if isinstance(value, MCPContext):
                 converted = SchwabContext.model_construct(
                     _request_context=value.request_context,
-                    _fastmcp=getattr(value, "_fastmcp", None),
+                    _mcp_server=getattr(value, "_mcp_server", None),
                 )
                 bound.arguments[name] = converted
                 context = converted
@@ -262,10 +262,10 @@ async def _report_approval_completion(context: SchwabContext, decision: Approval
 
 def _has_progress_token(context: SchwabContext) -> bool:
     try:
-        progress_token = getattr(context.request_context.meta, "progressToken", None)
+        meta = context.request_context.meta
     except ValueError:
         return False
-    return bool(progress_token)
+    return bool(meta.get("progress_token")) if meta else False
 
 
 def _wrap_result_transform(func: ToolFn, transform: Callable[[Any], Any]) -> ToolFn:
@@ -289,14 +289,14 @@ def _wrap_result_transform(func: ToolFn, transform: Callable[[Any], Any]) -> Too
 
 
 def register_tool(
-    server: FastMCP,
+    server: MCPServer,
     func: ToolFn,
     *,
     write: bool = False,
     annotations: ToolAnnotations | None = None,
     result_transform: Callable[[Any], Any] | None = None,
 ) -> None:
-    """Register a Schwab tool using FastMCP's decorator plumbing."""
+    """Register a Schwab tool using MCPServer's decorator plumbing."""
     func = _ensure_schwab_context(func)
     if write:
         func = _wrap_with_approval(func)
@@ -307,19 +307,19 @@ def register_tool(
     if tool_annotations is None:
         if write:
             tool_annotations = ToolAnnotations(
-                readOnlyHint=False,
-                destructiveHint=True,
+                read_only_hint=False,
+                destructive_hint=True,
             )
         else:
             tool_annotations = ToolAnnotations(
-                readOnlyHint=True,
+                read_only_hint=True,
             )
     else:
         update: dict[str, Any] = {}
-        if tool_annotations.readOnlyHint is None:
-            update["readOnlyHint"] = not write
-        if write and tool_annotations.destructiveHint is None:
-            update["destructiveHint"] = True
+        if tool_annotations.read_only_hint is None:
+            update["read_only_hint"] = not write
+        if write and tool_annotations.destructive_hint is None:
+            update["destructive_hint"] = True
         if update:
             tool_annotations = tool_annotations.model_copy(update=update)
 

--- a/src/schwab_mcp/tools/account.py
+++ b/src/schwab_mcp/tools/account.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -222,7 +222,7 @@ _READ_ONLY_TOOLS = (
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/history.py
+++ b/src/schwab_mcp/tools/history.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -83,7 +83,7 @@ _READ_ONLY_TOOLS = (get_advanced_price_history,)
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/options.py
+++ b/src/schwab_mcp/tools/options.py
@@ -4,7 +4,7 @@ import datetime
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -242,7 +242,7 @@ _READ_ONLY_TOOLS = (
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/orders.py
+++ b/src/schwab_mcp/tools/orders.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Annotated, Any, cast
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.types import ToolAnnotations
 from schwab.orders.common import Duration, first_triggers_second as trigger_builder, one_cancels_other as oco_builder
 from schwab.orders.generic import OrderBuilder
@@ -309,7 +309,7 @@ class _OrderDescInputRequired(TypedDict):
 class _OrderDescInput(_OrderDescInputRequired, total=False):
     """TypedDict used as the MCP tool parameter type for order leg dicts.
 
-    FastMCP generates the JSON schema for tool inputs from this TypedDict.
+    MCPServer generates the JSON schema for tool inputs from this TypedDict.
     Raw dicts received from MCP clients are validated and converted to
     ``OrderDesc`` dataclass instances via ``OrderDesc.from_dict()`` before
     any internal processing occurs.
@@ -1290,7 +1290,7 @@ _WRITE_TOOLS = (cancel_order,)  # keeps automatic argument-dump approval
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,
@@ -1312,6 +1312,6 @@ def register(
         server,
         place_previewed_order,
         write=False,
-        annotations=ToolAnnotations(readOnlyHint=False, destructiveHint=True),
+        annotations=ToolAnnotations(read_only_hint=False, destructive_hint=True),
         result_transform=result_transform,
     )

--- a/src/schwab_mcp/tools/quotes.py
+++ b/src/schwab_mcp/tools/quotes.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -82,7 +82,7 @@ _READ_ONLY_TOOLS = (get_quotes,)
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/__init__.py
+++ b/src/schwab_mcp/tools/technical/__init__.py
@@ -9,7 +9,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from mcp.server.fastmcp import FastMCP
+    from mcp.server.mcpserver import MCPServer
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ pandas_ta = cast(Any, _pandas_ta)
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/momentum.py
+++ b/src/schwab_mcp/tools/technical/momentum.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -100,7 +100,7 @@ async def stoch(
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/moving_average.py
+++ b/src/schwab_mcp/tools/technical/moving_average.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Annotated, Any
 
 import pandas as pd
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -66,7 +66,7 @@ async def moving_average(
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/overlays.py
+++ b/src/schwab_mcp/tools/technical/overlays.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Annotated, Any
 
 import pandas as pd
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -230,7 +230,7 @@ async def bollinger_bands(
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/trend.py
+++ b/src/schwab_mcp/tools/technical/trend.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -134,7 +134,7 @@ async def adx(
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/technical/volatility.py
+++ b/src/schwab_mcp/tools/technical/volatility.py
@@ -9,7 +9,7 @@ from typing import Annotated, Any, cast
 
 import numpy as np
 import pandas as pd
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -279,7 +279,7 @@ async def expected_move(
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/tools.py
+++ b/src/schwab_mcp/tools/tools.py
@@ -5,7 +5,7 @@ from collections.abc import Callable
 from typing import Annotated, Any
 from zoneinfo import ZoneInfo
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -123,7 +123,7 @@ _READ_ONLY_TOOLS = (
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/src/schwab_mcp/tools/transactions.py
+++ b/src/schwab_mcp/tools/transactions.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Annotated, Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.context import SchwabContext
 from schwab_mcp.tools._registration import register_tool
@@ -69,7 +69,7 @@ _READ_ONLY_TOOLS = (
 
 
 def register(
-    server: FastMCP,
+    server: MCPServer,
     *,
     allow_write: bool,
     result_transform: Callable[[Any], Any] | None = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def make_ctx(client: Any) -> SchwabContext:
     )
     return SchwabContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
 
 

--- a/tests/test_approval_wrapping.py
+++ b/tests/test_approval_wrapping.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from typing import Any, TypeVar, cast
 
 import pytest
-from mcp.server.fastmcp import Context as MCPContext
+from mcp.server.mcpserver import Context as MCPContext
 from schwab.client import AsyncClient
 
 from schwab_mcp.approvals import (
@@ -37,17 +37,14 @@ class DummySession:
     async def send_log_message(self, **payload: Any) -> None:
         self.messages.append(payload)
 
-    async def send_progress_notification(
+    async def report_progress(
         self,
-        *,
-        progress_token: str,
         progress: float,
-        total: float | None,
-        message: str | None,
+        total: float | None = None,
+        message: str | None = None,
     ) -> None:
         self.progress.append(
             {
-                "progress_token": progress_token,
                 "progress": progress,
                 "total": total,
                 "message": message,
@@ -66,7 +63,9 @@ def make_ctx(
         approval_manager=approval_manager,
     )
     session = DummySession()
-    meta = SimpleNamespace(progressToken=progress_token, client_id="client-123") if progress_token else None
+    meta: dict[str, Any] | None = (
+        {"progress_token": progress_token, "client_id": "client-123"} if progress_token else None
+    )
     request_context = SimpleNamespace(
         lifespan_context=lifespan_context,
         request_id="req-123",
@@ -75,7 +74,7 @@ def make_ctx(
     )
     ctx = SchwabContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
     return ctx, approval_manager, session, request_context
 
@@ -141,7 +140,7 @@ def test_write_tool_accepts_base_context() -> None:
     _, approval_manager, session, request_context = make_ctx(ApprovalDecision.APPROVED)
     base_ctx = MCPContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
     tool = wrapped_tool()
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,8 +5,8 @@ from types import SimpleNamespace
 from typing import Annotated, Any, cast
 
 import pytest
-from mcp.server.fastmcp import Context as MCPContext, FastMCP
-from mcp.server.fastmcp.tools import Tool
+from mcp.server.mcpserver import Context as MCPContext, MCPServer
+from mcp.server.mcpserver.tools import Tool
 from mcp.types import ToolAnnotations
 from schwab.client import AsyncClient
 
@@ -26,37 +26,37 @@ async def _dummy_tool(ctx: SchwabContext) -> str:  # noqa: ARG001
     return "ok"
 
 
-def _registered_tools(server: FastMCP) -> list[Tool]:
+def _registered_tools(server: MCPServer) -> list[Tool]:
     manager = getattr(server, "_tool_manager")
     return cast(list[Tool], manager.list_tools())
 
 
-def _tool_by_name(server: FastMCP, name: str) -> Tool:
+def _tool_by_name(server: MCPServer, name: str) -> Tool:
     tools = {tool.name: tool for tool in _registered_tools(server)}
     return tools[name]
 
 
 def test_register_tool_sets_readonly_annotations() -> None:
-    server = FastMCP(name="readonly")
+    server = MCPServer(name="readonly")
     register_tool(server, _dummy_tool)
 
     tool = _tool_by_name(server, "_dummy_tool")
     annotations = tool.annotations
     assert isinstance(annotations, ToolAnnotations)
-    assert annotations.readOnlyHint is True
-    assert annotations.destructiveHint is None
+    assert annotations.read_only_hint is True
+    assert annotations.destructive_hint is None
     assert tool.description == (_dummy_tool.__doc__ or "")
 
 
 def test_register_tool_sets_write_annotations() -> None:
-    server = FastMCP(name="write")
+    server = MCPServer(name="write")
     register_tool(server, _dummy_tool, write=True)
 
     tool = _tool_by_name(server, "_dummy_tool")
     annotations = tool.annotations
     assert isinstance(annotations, ToolAnnotations)
-    assert annotations.readOnlyHint is False
-    assert annotations.destructiveHint is True
+    assert annotations.read_only_hint is False
+    assert annotations.destructive_hint is True
     assert tool.description == (_dummy_tool.__doc__ or "")
 
 
@@ -81,7 +81,7 @@ def test_register_tools_always_registers_write_tools(monkeypatch) -> None:
     dummy_module = SimpleNamespace(register=register_module)
     monkeypatch.setattr(tools_module, "_TOOL_MODULES", (dummy_module,))
 
-    read_only_server = FastMCP(name="read-only")
+    read_only_server = MCPServer(name="read-only")
     tools_module.register_tools(
         read_only_server,
         cast(AsyncClient, object()),
@@ -91,9 +91,9 @@ def test_register_tools_always_registers_write_tools(monkeypatch) -> None:
     read_only_tools = {tool.name: tool for tool in _registered_tools(read_only_server)}
     assert {"read_tool", "write_tool"} == set(read_only_tools)
     assert read_only_tools["write_tool"].annotations is not None
-    assert read_only_tools["write_tool"].annotations.readOnlyHint is False
+    assert read_only_tools["write_tool"].annotations.read_only_hint is False
 
-    write_server = FastMCP(name="read-write")
+    write_server = MCPServer(name="read-write")
     tools_module.register_tools(
         write_server,
         cast(AsyncClient, object()),
@@ -104,12 +104,12 @@ def test_register_tools_always_registers_write_tools(monkeypatch) -> None:
     assert {"read_tool", "write_tool"} == set(write_tools)
     write_annotations = write_tools["write_tool"].annotations
     assert write_annotations is not None
-    assert write_annotations.readOnlyHint is False
-    assert write_annotations.destructiveHint is True
+    assert write_annotations.read_only_hint is False
+    assert write_annotations.destructive_hint is True
 
 
 def test_register_tool_applies_result_transform() -> None:
-    server = FastMCP(name="transform")
+    server = MCPServer(name="transform")
 
     async def sample_tool() -> dict[str, str]:
         return {"ok": "yes"}
@@ -133,7 +133,7 @@ def test_register_tool_applies_result_transform() -> None:
 
 def test_result_transform_handles_sync_tool() -> None:
     """_wrap_result_transform works when the wrapped function returns synchronously."""
-    server = FastMCP(name="sync-transform")
+    server = MCPServer(name="sync-transform")
 
     def sync_tool() -> str:  # type: ignore[return-value]
         return "raw"
@@ -149,7 +149,7 @@ def test_result_transform_handles_sync_tool() -> None:
 
 
 def test_result_transform_preserves_strings() -> None:
-    server = FastMCP(name="string-transform")
+    server = MCPServer(name="string-transform")
 
     async def sample_tool() -> str:
         return "already-string"
@@ -272,7 +272,7 @@ def test_ensure_schwab_context_converts_mcp_context() -> None:
 
     base_ctx = MCPContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
 
     async def runner() -> str:
@@ -308,7 +308,7 @@ def test_ensure_schwab_context_handles_sync_result() -> None:
     request_context = _make_request_context()
     ctx = SchwabContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
 
     async def runner() -> Any:
@@ -329,38 +329,38 @@ async def _noop_tool(ctx: SchwabContext) -> str:  # noqa: ARG001
 
 
 def test_register_tool_fills_readonly_hint_when_missing() -> None:
-    """readOnlyHint=None in caller-supplied annotations is filled based on write flag."""
-    server = FastMCP(name="hint-test")
-    partial_annotations = ToolAnnotations(readOnlyHint=None, destructiveHint=None)
+    """read_only_hint=None in caller-supplied annotations is filled based on write flag."""
+    server = MCPServer(name="hint-test")
+    partial_annotations = ToolAnnotations(read_only_hint=None, destructive_hint=None)
     register_tool(server, _noop_tool, annotations=partial_annotations)
 
     tool = _tool_by_name(server, "_noop_tool")
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True  # non-write tool → True
+    assert tool.annotations.read_only_hint is True  # non-write tool → True
 
 
 def test_register_tool_fills_destructive_hint_for_write_tools() -> None:
-    """destructiveHint=None is filled to True for write tools."""
-    server = FastMCP(name="destructive-test")
-    partial_annotations = ToolAnnotations(readOnlyHint=False, destructiveHint=None)
+    """destructive_hint=None is filled to True for write tools."""
+    server = MCPServer(name="destructive-test")
+    partial_annotations = ToolAnnotations(read_only_hint=False, destructive_hint=None)
     register_tool(server, _noop_tool, write=True, annotations=partial_annotations)
 
     tool = _tool_by_name(server, "_noop_tool")
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is False
-    assert tool.annotations.destructiveHint is True
+    assert tool.annotations.read_only_hint is False
+    assert tool.annotations.destructive_hint is True
 
 
 def test_register_tool_preserves_explicit_annotation_values() -> None:
     """Explicitly set annotation values are not overwritten."""
-    server = FastMCP(name="explicit-test")
-    explicit_annotations = ToolAnnotations(readOnlyHint=True, destructiveHint=False)
+    server = MCPServer(name="explicit-test")
+    explicit_annotations = ToolAnnotations(read_only_hint=True, destructive_hint=False)
     register_tool(server, _noop_tool, write=True, annotations=explicit_annotations)
 
     tool = _tool_by_name(server, "_noop_tool")
     assert tool.annotations is not None
-    assert tool.annotations.readOnlyHint is True
-    assert tool.annotations.destructiveHint is False
+    assert tool.annotations.read_only_hint is True
+    assert tool.annotations.destructive_hint is False
 
 
 # ---------------------------------------------------------------------------
@@ -381,7 +381,7 @@ def test_wrapped_tool_resolves_forward_ref_annotations() -> None:
 
     annotated_tool.__module__ = __name__
 
-    server = FastMCP(name="fwd-ref")
+    server = MCPServer(name="fwd-ref")
     register_tool(server, annotated_tool, result_transform=lambda v: v)
 
     tool = _tool_by_name(server, "annotated_tool")
@@ -389,7 +389,7 @@ def test_wrapped_tool_resolves_forward_ref_annotations() -> None:
     request_context = _make_request_context()
     ctx = SchwabContext.model_construct(
         _request_context=cast(Any, request_context),
-        _fastmcp=None,
+        _mcp_server=None,
     )
 
     result = asyncio.run(tool.fn(ctx))

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from schwab_mcp.resources import (
     OPTION_SYMBOLS,
@@ -49,7 +49,7 @@ class TestRegisterResources:
     def test_registers_static_resources(self):
         import asyncio
 
-        server = FastMCP(name="test")
+        server = MCPServer(name="test")
         register_resources(server)
 
         resources = asyncio.run(server.list_resources())

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -60,7 +60,7 @@ def test_server_configures_client_lifespan() -> None:
             assert approval_manager.started is True
 
     asyncio.run(runner())
-    # Process-scoped AsyncClient must outlive FastMCP lifespan teardown
+    # Process-scoped AsyncClient must outlive MCPServer lifespan teardown
     # (streamable-HTTP may exit lifespan per MCP session).
     assert dummy_client.closed is False
     assert dummy_client.calls == 0
@@ -207,7 +207,7 @@ def test_json_strip_transform_returns_string_payload_unchanged(monkeypatch) -> N
 
 @pytest.mark.anyio
 async def test_server_run_calls_run_stdio_async(monkeypatch) -> None:
-    """server.run() must delegate to FastMCP's run_stdio_async."""
+    """server.run() must delegate to MCPServer's run_stdio_async."""
     called: dict[str, bool] = {}
 
     dummy_client = DummyAsyncClient()
@@ -230,8 +230,8 @@ async def test_server_run_calls_run_stdio_async(monkeypatch) -> None:
 
 @pytest.mark.anyio
 async def test_server_run_http_calls_streamable_http(monkeypatch) -> None:
-    """--http path must set host/port and use run_streamable_http_async."""
-    called: dict[str, bool] = {}
+    """--http path must pass host/port to run_streamable_http_async."""
+    called: dict[str, Any] = {}
 
     dummy_client = DummyAsyncClient()
     client = cast(AsyncClient, dummy_client)
@@ -243,14 +243,15 @@ async def test_server_run_http_calls_streamable_http(monkeypatch) -> None:
         allow_write=False,
     )
 
-    async def fake_run_streamable_http_async() -> None:
+    async def fake_run_streamable_http_async(**kwargs: Any) -> None:
         called["http"] = True
+        called["kwargs"] = kwargs
 
     monkeypatch.setattr(server._server, "run_streamable_http_async", fake_run_streamable_http_async)
     await server.run(transport="http", host="127.0.0.1", port=3473)
     assert called.get("http") is True
-    assert server._server.settings.host == "127.0.0.1"
-    assert server._server.settings.port == 3473
+    assert called["kwargs"]["host"] == "127.0.0.1"
+    assert called["kwargs"]["port"] == 3473
 
 
 def test_send_error_response_defaults_details_to_empty_dict(monkeypatch) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -810,6 +810,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -825,12 +838,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1011,15 +1041,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -1029,15 +1059,28 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
 cli = [
     { name = "python-dotenv" },
     { name = "typer" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
 ]
 
 [[package]]
@@ -1426,6 +1469,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -1910,20 +1965,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -2498,7 +2539,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.3.0" },
     { name = "discord-py", specifier = ">=2.4.0" },
     { name = "httpx", specifier = ">=0.27.2" },
-    { name = "mcp", specifier = ">=1.17.0,<2" },
+    { name = "mcp", specifier = ">=2.0.0,<3" },
     { name = "platformdirs", specifier = ">=4.5.0" },
     { name = "python-toon", specifier = ">=0.1.2" },
     { name = "pyyaml", specifier = ">=6.0.3" },
@@ -2508,7 +2549,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mcp", extras = ["cli"], specifier = ">=1.17.0,<2" },
+    { name = "mcp", extras = ["cli"], specifier = ">=2.0.0,<3" },
     { name = "pyright", specifier = ">=1.1.407" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -2634,6 +2675,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Migrate from `mcp` Python SDK v1.28.1 to v2.0.0. This lifts the `<2` cap landed in #160 and follows the upstream [v2 migration guide](https://github.com/modelcontextprotocol/python-sdk/blob/main/docs/migration.md).

## Why

`mcp 2.0.0` is the stable line; v1.x is now maintenance-only (security patches, no features). The stopgap PR (#160) pinned `mcp<2` so Renovate's lock-file-maintenance could land green. This PR does the migration the stopgap deferred.

## What changed in v2

- `FastMCP` renamed to `MCPServer` at `mcp.server.mcpserver` (the `mcp.server.fastmcp` import path is gone, not deprecated)
- Wire types moved to the standalone `mcp-types` package (re-exported through `mcp.types`)
- Every `ToolAnnotations` field is now snake_case (`readOnlyHint` → `read_only_hint`, `destructiveHint` → `destructive_hint`); JSON on the wire stays camelCase via Pydantic aliases
- `Context` narrowed from three generic params to two (`Context[LifespanContextT, RequestT]`)
- `Context._fastmcp` → `Context._mcp_server`; `get_context()` removed (declaration is the new pattern)
- `RequestParams.Meta` Pydantic model → `RequestParamsMeta` TypedDict; attribute access becomes dict access
- Transport params (`host`, `port`, `stateless_http`, etc.) moved off the `MCPServer` constructor and `Settings` to `run()` / `run_streamable_http_async()`
- `Context.report_progress()` now delegates to `session.report_progress()` instead of `session.send_progress_notification()`
- `httpx`/`httpx-sse` replaced by `httpx2` (only affects MCP transports; `schwab-py` keeps its own `httpx` dependency for Schwab OAuth)

## What changed in this repo

- **Imports** across `server.py`, `context.py`, `_registration.py`, every `tools/*.py`, `tools/technical/*.py`, `resources.py`, and the test suite: `mcp.server.fastmcp` → `mcp.server.mcpserver`, `FastMCP` → `MCPServer`.
- **`context.py`**: narrowed `SchwabContext(MCPContext[Any, SchwabServerContext, Any])` to `SchwabContext(MCPContext[SchwabServerContext, Any])`; added a `client_id` property (v1 inherited it from `Context`, v2 does not) that reads `request_context.meta.get("client_id")`.
- **`_registration.py`**: `_fastmcp` → `_mcp_server` in the two `SchwabContext.model_construct()` call sites; `ToolAnnotations` constructor and attribute access switched to snake_case; `_has_progress_token` rewritten for the `RequestParamsMeta` TypedDict (`meta.get("progress_token")` instead of `getattr(meta, "progressToken")`).
- **`server.py`**: `SchwabMCPServer.run()` now passes `host`/`port` directly to `run_streamable_http_async()` instead of mutating `self._server.settings.host`/`.port` (those fields no longer exist on `Settings`).
- **`orders.py`**: the `ToolAnnotations(readOnlyHint=..., destructiveHint=...)` annotation on `place_previewed_order` switched to snake_case.
- **Tests**: `tests/test_approval_wrapping.py` `DummySession.send_progress_notification` renamed to `report_progress` with the v2 signature; `make_ctx` now builds `meta` as a dict matching `RequestParamsMeta`; `tests/test_server.py` asserts the new `run_streamable_http_async(host=..., port=...)` kwargs instead of `settings.host/port`; `tests/test_registry.py` snake_case `ToolAnnotations` assertions; all `_fastmcp` test fixtures → `_mcp_server`.

## Verification

All local CI gates green:

- `uv run pyright` — 0 errors
- `uv run ruff check .` / `uv run ruff format --check .` — clean
- `uv run pytest` — 590 passed

## Notes

- `httpx` references in `src/schwab_mcp/auth.py` and `tests/test_auth.py` belong to `schwab-py`'s own auth flow (its own `httpx` dependency), not the MCP SDK transport, so no `httpx2` swap is needed there.
- Codemap markdown files still reference `FastMCP` in prose; those describe architecture at a higher level and can be updated in a follow-up docs pass if desired.
- `pyproject.toml` now declares `mcp>=2.0.0,<3`.